### PR TITLE
feat: streaming pipeline for CSV ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Database Monitoring
+
+## Streaming CSV ingestion
+
+A pipeline de ingestão agora processa arquivos CSV em **streaming**, lendo linha a linha e montando lotes para inserção assíncrona no MySQL. O fluxo mantém baixo uso de memória, inicia as inserções antes do fim da leitura e registra logs por lote.
+
+### Variáveis de ambiente
+
+- `BATCH_SIZE` – quantidade de linhas por lote (padrão: 10000).
+- `MAX_CONCURRENT_INSERTS` – número máximo de inserções concorrentes (padrão: 1).
+- `QUEUE_HIGH_WATERMARK` – número de lotes em voo para pausar a leitura (padrão: 2).
+- `QUEUE_LOW_WATERMARK` – limite para retomar a leitura após pausa (padrão: 1).
+
+Defina-as conforme o tamanho dos arquivos e a capacidade do banco para ajustar throughput e backpressure.

--- a/src/controller/managerDataController.js
+++ b/src/controller/managerDataController.js
@@ -1,8 +1,4 @@
-import {
-  insertRegisterinTable,
-  insertBatchInTable,
-  deleteFromTable,
-} from "../model/tableModel.js";
+import { deleteFromTable } from "../model/tableModel.js";
 import {
   iniciarBarra,
   atualizarBarra,
@@ -11,12 +7,11 @@ import {
 
 import { addAviso, addErro, addInfo } from "../middleware/errorHandler.js";
 import { updateLoggerController } from "../middleware/logger.js";
-import { streamCsvRows } from "../utils/csvStream.js";
+import streamPipeline from "../utils/streamPipeline.js";
 import {
   detectDelimiter,
   detectEncoding,
 } from "../utils/prepareStreamByFilepath.js";
-import sanitizeRow from "../utils/sanitizeValue.js";
 import {
   loadDecimalProfilesFromSchema,
   expandTiposWithSchema,
@@ -116,131 +111,13 @@ export async function manageInsertController(metadados) {
 
     addInfo("Iniciando leitura e montagem de lotes...", contexto);
 
-    // -------- Fase 2 (read): leitura/sanitização + pipeline de insert --------
-    const BATCH_ROWS_CAP = 10_000;               // limite por linhas
-    const MAX_BATCH_BYTES = 48 * 1024 * 1024;    // ~75% de 64MB (max_allowed_packet)
-    const HWM = 1024 * 1024;                     // 1 MiB na leitura
-
-    let batch = [];
-    let batchBytes = 0;                           // acumulador de bytes do lote
-    let lidas = 0;
-    let inseridosAteAgora = 0;
-    const cols = metadados.colunas_tabela;
-    const order = cols.map(c => c.name || c);     // ordem das colunas no INSERT
-
-    // progress durante inserts
-    function publishInsertStatus(texto) {
-      const p = total > 0 ? Math.min(1, inseridosAteAgora / total) : 1;
-      publish(p, texto);
-    }
-
-    // estima bytes do payload do INSERT para essa linha (protocolo texto)
-    function approxRowBytes(row) {
-      let bytes = 2; // "(" ")"
-      for (let i = 0; i < order.length; i++) {
-        const v = row[order[i]];
-        if (v == null) {
-          bytes += 4; // NULL
-        } else if (typeof v === "number") {
-          bytes += 24; // número em texto (pior caso)
-        } else {
-          const s = String(v);
-          // 2 aspas + tamanho utf8 + ~10% para escapes de aspas/backs
-          bytes += 2 + Buffer.byteLength(s, "utf8") + Math.ceil(s.length * 0.10);
-        }
-        bytes += 1; // vírgula
-      }
-      return bytes + 1; // separador/fechamento
-    }
-
-    // pipeline: no máx 1 lote em voo (sobrepõe leitura ↔ insert sem explodir memória)
-    let inflight = null;
-    let insertPhaseStarted = false;
-
-    async function doInsert(lote) {
-      atualizarBarra(barraId, 0, `Inserindo ${lote.length} registros no banco...`);
-      if (!insertPhaseStarted) { setPhase("insert"); insertPhaseStarted = true; }
-      try {
-        await insertBatchInTable(metadados.tabela, lote, cols, { skipUpdateClause: true });
-        inseridosAteAgora += lote.length;
-        publishInsertStatus(`Inseridos: ${inseridosAteAgora}/${total}`);
-      } catch (e) {
-        addAviso(`[BATCH] Falha no lote (${lote.length}). Fallback linha-a-linha. Motivo: ${e.message}`, contexto);
-        void updateLoggerController(metadados, contexto);
-
-        let ok = 0, fail = 0;
-        for (const row of lote) {
-          try {
-            await insertRegisterinTable(metadados.tabela, row, cols);
-            ok++; inseridosAteAgora++;
-          } catch (err) {
-            fail++; addErro(`Erro ao inserir linha ${inseridosAteAgora + 1}: ${err.message}`, contexto);
-          } finally {
-            publishInsertStatus(`Fallback: ok=${ok}, fail=${fail}`);
-          }
-        }
-      }
-    }
-
-    async function flushBatch() {
-      if (batch.length === 0) return;
-      const lote = batch;
-      batch = [];            // limpa antes do insert para liberar memória
-      batchBytes = 0;        // zera contador de bytes do lote
-      if (inflight) {
-        inflight = inflight.then(() => doInsert(lote));
-      } else {
-        inflight = doInsert(lote);
-      }
-    }
-
     try {
-      let currentBatchCount = 0;
-
-      for await (const linhaOriginal of streamCsvRows(
-        contexto,
-        headersNorm,
-        encoding,
-        delimiter,
-        { highWaterMark: HWM }
-      )) {
-        const linhaTipada = sanitizeRow(linhaOriginal, tiposFinal, contexto);
-
-        const rowBytes = approxRowBytes(linhaTipada);
-
-        // cap por linhas OU por bytes → flush antes de adicionar a próxima
-        if (batch.length > 0 && (batch.length >= BATCH_ROWS_CAP || (batchBytes + rowBytes) > MAX_BATCH_BYTES)) {
-          atualizarBarra(barraId, 0, `Enviando lote (cap atingido)...`);
-          await flushBatch();
-          currentBatchCount = 0;
-
-          // backpressure simples: no máx. 1 lote em voo
-          if (inflight) { await inflight; inflight = null; }
-        }
-
-        batch.push(linhaTipada);
-        batchBytes += rowBytes;
-        currentBatchCount++;
-        lidas++;
-
-        // avança fase read (15..60%) com base em lidas/total
-        publish(lidas / total, `Montando lote (${currentBatchCount}/${BATCH_ROWS_CAP})`);
-      }
-
-      // envia o resto do último lote
-      await flushBatch();
-
-      // aguarda o último insert em voo (se houver)
-      if (inflight) {
-        await inflight;
-        inflight = null;
-      }
-
-      if (!insertPhaseStarted) {
-        publish(1.0, "Leitura & sanitização concluídas");
-        setPhase("insert");
-        publish(1.0, "Sem inserções necessárias");
-      }
+      const resultado = await streamPipeline(metadados, tiposFinal, {
+        publishRead: (lidas) => publish(lidas / total, "Montando lote..."),
+        publishInsert: (inseridos) => publish(inseridos / total, `Inseridos: ${inseridos}/${total}`),
+        onInsertStart: () => setPhase("insert"),
+        onFlush: () => atualizarBarra(barraId, 0, "Enviando lote..."),
+      });
 
       // finaliza em 100%
       if (lastPctAbs < 100) {
@@ -250,13 +127,7 @@ export async function manageInsertController(metadados) {
 
       addInfo("Processo de inserção finalizado.", contexto);
 
-      return {
-        erro: false,
-        total,
-        inseridos: inseridosAteAgora,
-        falhas: Math.max(0, total - inseridosAteAgora),
-        mensagem: null,
-      };
+      return resultado;
     } catch (e) {
       addErro(`Falha no pipeline de leitura/inserção: ${e.message}`, contexto);
       void updateLoggerController(metadados, contexto);

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,0 +1,4 @@
+export const BATCH_SIZE = Number(process.env.BATCH_SIZE) || 10000;
+export const MAX_CONCURRENT_INSERTS = Number(process.env.MAX_CONCURRENT_INSERTS) || 1;
+export const QUEUE_HIGH_WATERMARK = Number(process.env.QUEUE_HIGH_WATERMARK) || 2;
+export const QUEUE_LOW_WATERMARK = Number(process.env.QUEUE_LOW_WATERMARK) || 1;

--- a/src/utils/streamPipeline.js
+++ b/src/utils/streamPipeline.js
@@ -1,0 +1,148 @@
+import pLimit from "p-limit";
+import { streamCsvRows } from "./csvStream.js";
+import sanitizeRow from "./sanitizeValue.js";
+import { insertBatchInTable, insertRegisterinTable } from "../model/tableModel.js";
+import { addAviso, addErro } from "../middleware/errorHandler.js";
+import { updateLoggerController } from "../middleware/logger.js";
+import {
+  BATCH_SIZE,
+  MAX_CONCURRENT_INSERTS,
+  QUEUE_HIGH_WATERMARK,
+  QUEUE_LOW_WATERMARK,
+} from "./config.js";
+
+/**
+ * Executa a ingestão de um CSV em modo streaming.
+ * @param {object} metadados Informações do CSV e da tabela de destino.
+ * @param {object} tiposFinal Tipos normalizados das colunas.
+ * @param {object} opts Callbacks de progresso.
+ */
+export async function streamPipeline(metadados, tiposFinal, opts = {}) {
+  const {
+    publishRead,
+    publishInsert,
+    onInsertStart,
+    onFlush,
+  } = opts;
+
+  const {
+    caminho_original: contexto,
+    tabela,
+    colunas_json: headersNorm,
+    colunas_tabela: cols,
+    encoding,
+    delimiter,
+    total_linhas: total,
+  } = metadados;
+
+  const BATCH_ROWS_CAP = BATCH_SIZE;
+  const MAX_BATCH_BYTES = 48 * 1024 * 1024;
+  const HWM = 1024 * 1024;
+
+  const order = cols.map((c) => c.name || c);
+
+  function approxRowBytes(row) {
+    let bytes = 2; // "(" ")"
+    for (let i = 0; i < order.length; i++) {
+      const v = row[order[i]];
+      if (v == null) {
+        bytes += 4; // NULL
+      } else if (typeof v === "number") {
+        bytes += 24; // número em texto
+      } else {
+        const s = String(v);
+        bytes += 2 + Buffer.byteLength(s, "utf8") + Math.ceil(s.length * 0.1);
+      }
+      bytes += 1; // vírgula
+    }
+    return bytes + 1;
+  }
+
+  const limit = pLimit(MAX_CONCURRENT_INSERTS);
+  const inflight = new Set();
+
+  let batch = [];
+  let batchBytes = 0;
+  let lidas = 0;
+  let inseridosAteAgora = 0;
+  let insertPhaseStarted = false;
+
+  async function doInsert(lote) {
+    if (!insertPhaseStarted) {
+      onInsertStart?.();
+      insertPhaseStarted = true;
+    }
+    try {
+      await insertBatchInTable(tabela, lote, cols, { skipUpdateClause: true });
+      inseridosAteAgora += lote.length;
+      publishInsert?.(inseridosAteAgora, total);
+    } catch (e) {
+      addAviso(
+        `[BATCH] Falha no lote (${lote.length}). Fallback linha-a-linha. Motivo: ${e.message}`,
+        contexto,
+      );
+      let ok = 0, fail = 0;
+      for (const row of lote) {
+        try {
+          await insertRegisterinTable(tabela, row, cols);
+          ok++; inseridosAteAgora++;
+        } catch (err) {
+          fail++; addErro(`Erro ao inserir linha ${inseridosAteAgora + 1}: ${err.message}`, contexto);
+        }
+      }
+      publishInsert?.(inseridosAteAgora, total);
+    } finally {
+      await updateLoggerController(metadados, contexto);
+    }
+  }
+
+  async function flushBatch() {
+    if (batch.length === 0) return;
+    const lote = batch;
+    batch = [];
+    batchBytes = 0;
+    onFlush?.(lote.length);
+    const p = limit(() => doInsert(lote));
+    inflight.add(p);
+    p.finally(() => inflight.delete(p));
+  }
+
+  for await (const linhaOriginal of streamCsvRows(
+    contexto,
+    headersNorm,
+    encoding,
+    delimiter,
+    { highWaterMark: HWM },
+  )) {
+    const linhaTipada = sanitizeRow(linhaOriginal, tiposFinal, contexto);
+    const rowBytes = approxRowBytes(linhaTipada);
+
+    if (batch.length > 0 && (batch.length >= BATCH_ROWS_CAP || (batchBytes + rowBytes) > MAX_BATCH_BYTES)) {
+      await flushBatch();
+      while (inflight.size >= QUEUE_HIGH_WATERMARK) {
+        await Promise.race(inflight);
+      }
+      while (inflight.size > QUEUE_LOW_WATERMARK) {
+        await Promise.race(inflight);
+      }
+    }
+
+    batch.push(linhaTipada);
+    batchBytes += rowBytes;
+    lidas++;
+    publishRead?.(lidas, total, batch.length);
+  }
+
+  await flushBatch();
+  await Promise.all(inflight);
+
+  return {
+    erro: false,
+    total,
+    inseridos: inseridosAteAgora,
+    falhas: Math.max(0, total - inseridosAteAgora),
+    mensagem: null,
+  };
+}
+
+export default streamPipeline;


### PR DESCRIPTION
## Summary
- add streaming pipeline to process CSV rows in batches
- refactor controller to use the streaming pipeline
- update logger to track batch inserts
- expose env vars for batch size and concurrency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c28fc1888324b287e7ed6fbbc125