### PR TITLE
Filter non-CSV file events and deduplicate logger messages

### DIFF
--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -20,25 +20,38 @@ async function safeAppendToLog(contexto, tipo, msg) {
 /* ─────────────────────────────── */
 function ensureContext(contexto) {
   if (!contextoDeMensagens.has(contexto)) {
-    contextoDeMensagens.set(contexto, { erros: [], infos: [], avisos: [] });
+    contextoDeMensagens.set(contexto, {
+      erros: [],
+      infos: [],
+      avisos: [],
+      lastErro: null,
+      lastInfo: null,
+      lastAviso: null,
+    });
   }
   return contextoDeMensagens.get(contexto);
 }
 
 export function addErro(msg, contexto = "__global") {
   const bag = ensureContext(contexto);
+  if (bag.lastErro === msg) return;
+  bag.lastErro = msg;
   bag.erros.push(msg);
   void safeAppendToLog(contexto, "erro", msg);
 }
 
 export function addInfo(msg, contexto = "__global") {
   const bag = ensureContext(contexto);
+  if (bag.lastInfo === msg) return;
+  bag.lastInfo = msg;
   bag.infos.push(msg);
   void safeAppendToLog(contexto, "info", msg);
 }
 
 export function addAviso(msg, contexto = "__global") {
   const bag = ensureContext(contexto);
+  if (bag.lastAviso === msg) return;
+  bag.lastAviso = msg;
   bag.avisos.push(msg);
   void safeAppendToLog(contexto, "aviso", msg);
 }
@@ -47,12 +60,27 @@ export function addAviso(msg, contexto = "__global") {
 /* Utilitários                     */
 /* ─────────────────────────────── */
 export function getAllErrors(contexto = "__global") {
-  return (
-    contextoDeMensagens.get(contexto) || { erros: [], infos: [], avisos: [] }
-  );
+  const bag =
+    contextoDeMensagens.get(contexto) ||
+    {
+      erros: [],
+      infos: [],
+      avisos: [],
+      lastErro: null,
+      lastInfo: null,
+      lastAviso: null,
+    };
+  return { erros: bag.erros, infos: bag.infos, avisos: bag.avisos };
 }
 export function clearAllErrors(contexto = "__global") {
-  contextoDeMensagens.set(contexto, { erros: [], infos: [], avisos: [] });
+  contextoDeMensagens.set(contexto, {
+    erros: [],
+    infos: [],
+    avisos: [],
+    lastErro: null,
+    lastInfo: null,
+    lastAviso: null,
+  });
 }
 export function clearAllContexts() {
   contextoDeMensagens.clear();

--- a/src/monitoring.js
+++ b/src/monitoring.js
@@ -27,7 +27,15 @@ export async function startMonitoring() {
     usePolling: true,
     interval: 500,
     depth: 10,
-    ignored: /[\\\/]database_monitoring[\\\/]/,
+    ignored: (fp) => {
+      const lower = fp.toLowerCase();
+      return (
+        lower.includes("database_monitoring") ||
+        lower.includes("\\loggers\\") ||
+        lower.includes("/loggers/") ||
+        lower.endsWith(".txt")
+      );
+    },
     awaitWriteFinish: {
       stabilityThreshold: 300,
       pollInterval: 100,
@@ -56,14 +64,17 @@ export async function startMonitoring() {
 
   watcher
     .on("add", (filePath) => {
+      if (!isCsvFile(filePath)) return;
       console.log(`🟢 Arquivo adicionado: ${filePath}`);
       enfileirar(filePath, "created", createdHandler);
     })
     .on("change", (filePath) => {
+      if (!isCsvFile(filePath)) return;
       console.log(`🟡 Arquivo modificado: ${filePath}`);
       enfileirar(filePath, "modified", createdHandler);
     })
     .on("unlink", (filePath) => {
+      if (!isCsvFile(filePath)) return;
       console.log(`🔴 Arquivo removido: ${filePath}`);
       enfileirar(filePath, "deleted", deletedHandler);
     })


### PR DESCRIPTION
## Summary
- Ignore log folders and .txt files during monitoring and only log watcher events for CSVs
- Deduplicate repeated log messages per context to keep logger output concise

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf09b326e483249778fd013241266d