### PR TITLE
feat: enable fast-path single-pass CSV ingestion

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PIPELINE_FAST_PATH=true

--- a/src/controller/Handlers/createdHandler.js
+++ b/src/controller/Handlers/createdHandler.js
@@ -10,10 +10,14 @@ import { insertLog } from "../../model/logModel.js";
 import createDataController from "../createDataController.js";
 import fluxoValidatorController from "../fluxoValidatorController.js";
 import { manageInsertController } from "../managerDataController.js";
+import { PIPELINE_FAST_PATH } from "../../utils/config.js";
 
 
 
 export default async function createdHandler(filePath, action) {
+
+  // read fast-path flag (unused but kept for clarity)
+  const useFastPath = PIPELINE_FAST_PATH;
 
   if (!filePath) { addErro("caminho do arquivo não definido no handler, sem como identificar qual arquivo deu erro...", contexto); return; }
   let metadados, logData;
@@ -38,12 +42,15 @@ export default async function createdHandler(filePath, action) {
 
     if (fluxo !== "inserir" && fluxo !== "reprocessar") {
       addInfo(`[ARQUIVO IGNORADO] ${metadados.nome_arquivo} já existe e não foi modificado.`, filePath);
+      await insertLog(logData);
+      return;
     }
 
     try {
       const resultado = await manageInsertController(metadados);
       logData.sucesso = !resultado?.erro;
       logData.mensagem_erro = resultado?.mensagem || null;
+      logData.hash_arquivo = metadados.hash;
 
       if (resultado?.erro) addErro(logData.mensagem_erro, filePath);
     } catch (e) {

--- a/src/controller/createDataController.js
+++ b/src/controller/createDataController.js
@@ -1,6 +1,9 @@
 import path from "path";
-import { analyzeCsv } from "../utils/csvStream.js";
+import { analyzeCsv, readCsvHeader, normalizeHeadersOnce } from "../utils/csvStream.js";
 import { addAviso, addErro } from "../middleware/errorHandler.js";
+import { detectEncoding, detectDelimiter } from "../utils/prepareStreamByFilepath.js";
+import { getColumnsFromTable, getTiposFromTable, getDateColumnsFromTable } from "../model/tableModel.js";
+import { PIPELINE_FAST_PATH } from "../utils/config.js";
 
 
 
@@ -98,8 +101,43 @@ export async function createFundamentalDocsController(filePath, action, contexto
 
 export async function createMetadadosController(filePath, action) {
   const destino = destinoByFilePath(filePath);
-  const analise = await analyzeCsv(filePath, destino.tabela_destino);
   const caminho_truncado = truncarFilepath(filePath);
+
+  if (PIPELINE_FAST_PATH) {
+    const { encoding } = await detectEncoding(filePath, { headBytes: 64 * 1024, fallback: "latin1" });
+    const delimiter = await detectDelimiter(filePath, encoding, { minHeadBytes: 64 * 1024, maxHeadBytes: 64 * 1024 });
+    const rawHeaders = await readCsvHeader(filePath, encoding, delimiter, { highWaterMark: 64 * 1024, fastMode: true });
+    const { headers: headersNorm } = normalizeHeadersOnce(rawHeaders);
+    const [colunasTabela, tiposEsperados, colunaData] = await Promise.all([
+      getColumnsFromTable(destino.tabela_destino),
+      getTiposFromTable(destino.tabela_destino),
+      getDateColumnsFromTable(destino.tabela_destino),
+    ]);
+
+    return {
+      nome_arquivo: destino.nome_arquivo,
+      ano: destino.ano,
+      mes: destino.mes,
+      dia: destino.dia,
+      tabela: destino.tabela_destino,
+
+      hash: null,
+      encoding,
+      delimiter,
+      coluna_data: colunaData,
+      acao: action,
+      colunas_tabela: colunasTabela,
+      colunas_json: headersNorm,
+      tipos_esperados: tiposEsperados,
+      datas_csv: null,
+      total_linhas: 0,
+
+      caminho_original: filePath,
+      caminho_truncado,
+    };
+  }
+
+  const analise = await analyzeCsv(filePath, destino.tabela_destino);
 
   return {
     nome_arquivo: destino.nome_arquivo,
@@ -116,11 +154,11 @@ export async function createMetadadosController(filePath, action) {
     colunas_tabela: analise.colunas_tabela,
     colunas_json: analise.colunas_json,
     tipos_esperados: analise.tipos_esperados,
-    datas_csv: analise.datas_csv, 
+    datas_csv: analise.datas_csv,
     total_linhas: analise.total_linhas,
 
     caminho_original: filePath,
-    caminho_truncado, // evita recalcular no log
+    caminho_truncado,
   };
 }
 

--- a/src/controller/fluxoValidatorController.js
+++ b/src/controller/fluxoValidatorController.js
@@ -1,11 +1,35 @@
 import { addErro, addInfo } from "../middleware/errorHandler.js";
-import { updateLoggerController } from "../middleware/logger.js";
 import { getLogByData, getAllHashesFromTable } from "../model/logModel.js";
+import { existsAnyDataInRange } from "../model/tableModel.js";
+import { PIPELINE_FAST_PATH } from "../utils/config.js";
 
 export default async function fluxoValidatorController(metadados, logData) {
   const contexto = metadados.caminho_original;
   const nome = metadados.nome_arquivo;
   const tabela = metadados.tabela;
+
+  if (PIPELINE_FAST_PATH) {
+    try {
+      const overlap = await existsAnyDataInRange(metadados);
+      if (overlap) {
+        addInfo(
+          `[ARQUIVO MODIFICADO] [${nome}] já existia, mas foi alterado. Reprocessando.`,
+          contexto
+        );
+        console.log(
+          `[🟡 MODIFICADO] [${nome}] sera inserido na tabela [${tabela}]`
+        );
+        return "reprocessar";
+      }
+    } catch (e) {
+      addErro(`Erro ao verificar dados existentes: ${e.message}`, contexto);
+    }
+
+    addInfo(`[NOVO ARQUIVO] [${nome}] será processado.`, contexto);
+    console.log(`[🟢 NOVO] [${nome}] sera inserido na tabela [${tabela}]`);
+    return "inserir";
+  }
+
   const hash = logData?.hash_arquivo;
 
   if (!hash) {
@@ -22,7 +46,7 @@ export default async function fluxoValidatorController(metadados, logData) {
         .then((rows) => {
           if (!rows || rows.length === 0) return false;
           for (let i = 0; i < rows.length; i++) {
-            if (rows[i] && rows[i].hash_arquivo === hash) return true; 
+            if (rows[i] && rows[i].hash_arquivo === hash) return true;
           }
           return false;
         })
@@ -33,7 +57,6 @@ export default async function fluxoValidatorController(metadados, logData) {
     : Promise.resolve(false);
 
   const [logs, hashJaExiste] = await Promise.all([pLogs, pHashExiste]);
-
 
   if (hashJaExiste) {
     addInfo(

--- a/src/controller/managerDataController.js
+++ b/src/controller/managerDataController.js
@@ -1,4 +1,4 @@
-import { deleteFromTable } from "../model/tableModel.js";
+import { deleteFromTable, existsAnyDataInRange, existsAnyCsvDateInTable } from "../model/tableModel.js";
 import {
   iniciarBarra,
   atualizarBarra,
@@ -16,7 +16,7 @@ import {
   loadDecimalProfilesFromSchema,
   expandTiposWithSchema,
 } from "../model/tableModel.js";
-import { existsAnyCsvDateInTable } from "../model/tableModel.js";
+import { PIPELINE_FAST_PATH } from "../utils/config.js";
 
 export async function manageInsertController(metadados) {
   const contexto = metadados.caminho_original;
@@ -79,17 +79,12 @@ export async function manageInsertController(metadados) {
 
     // -------- Valida dados e ação --------
     const total = metadados.total_linhas || 0;
-    if (total === 0) {
-      addAviso("Nenhuma linha disponível para inserção.", contexto);
-      publish(1.0, "Nada a fazer");
-      setPhase("insert");
-      publish(1.0, "Sem inserções necessárias");
-      return { erro: false, total: 0, inseridos: 0, falhas: 0, mensagem: "Arquivo vazio" };
-    }
 
     let validator;
     try {
-      const overlap = await existsAnyCsvDateInTable(metadados); // true/false/null
+      const overlap = PIPELINE_FAST_PATH
+        ? await existsAnyDataInRange(metadados)
+        : await existsAnyCsvDateInTable(metadados); // true/false/null
       if (overlap === null) {
         // Sem coluna_data → segue sua regra original
         validator = "cadastro";
@@ -124,8 +119,8 @@ export async function manageInsertController(metadados) {
 
     try {
       const resultado = await streamPipeline(metadados, tiposFinal, {
-        publishRead: (lidas) => publish(lidas / total, "Montando lote..."),
-        publishInsert: (inseridos) => publish(inseridos / total, `Inseridos: ${inseridos}/${total}`),
+        publishRead: (lidas) => publish(total ? lidas / total : 0, "Montando lote..."),
+        publishInsert: (inseridos) => publish(total ? inseridos / total : 0, `Inseridos: ${inseridos}/${total}`),
         onInsertStart: () => setPhase("insert"),
         onFlush: () => atualizarBarra(barraId, 0, "Enviando lote..."),
       });

--- a/src/model/tableModel.js
+++ b/src/model/tableModel.js
@@ -72,6 +72,26 @@ function computeDateRange({ ano, mes, dia }) {
   return [i, f];
 }
 
+export async function existsAnyDataInRange(metadados) {
+  const { tabela, coluna_data, ano, mes, dia } = metadados;
+  if (!tabela || !coluna_data) return null;
+  const range = computeDateRange({ ano, mes, dia });
+  if (!range) return null;
+  const [inicio, fim] = range;
+  const sql = `
+      SELECT 1
+      FROM \`${schema}\`.\`${tabela}\`
+      WHERE \`${coluna_data}\` >= ? AND \`${coluna_data}\` < ?
+      LIMIT 1
+    `;
+  try {
+    const [rows] = await db.query(sql, [inicio, fim]);
+    return rows.length > 0;
+  } catch (e) {
+    throw new Error(`[model exists range] Erro ao consultar range de datas: ${e.message}`);
+  }
+}
+
 /** Gera "(?, ?, ...)" repetido N vezes e o array achatado de valores. */
 function buildMultiValuesPlaceholders(rows, cols) {
   const perRow = `(${cols.map(() => "?").join(",")})`;

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -2,3 +2,6 @@ export const BATCH_SIZE = Number(process.env.BATCH_SIZE) || 10000;
 export const MAX_CONCURRENT_INSERTS = Number(process.env.MAX_CONCURRENT_INSERTS) || 1;
 export const QUEUE_HIGH_WATERMARK = Number(process.env.QUEUE_HIGH_WATERMARK) || 2;
 export const QUEUE_LOW_WATERMARK = Number(process.env.QUEUE_LOW_WATERMARK) || 1;
+
+// Enable single-pass CSV ingestion when true (default: true)
+export const PIPELINE_FAST_PATH = process.env.PIPELINE_FAST_PATH !== "false";

--- a/src/utils/csvStream.js
+++ b/src/utils/csvStream.js
@@ -27,7 +27,7 @@ function rate(lins, msElapsed){
 }
 
 /* ────────────────────────── tee p/ hash e parse ───────────────────────── */
-function createFileTee(filePath, { highWaterMark = 1024 * 1024 } = {}) {
+export function createFileTee(filePath, { highWaterMark = 1024 * 1024 } = {}) {
   const src = createReadStream(filePath, { highWaterMark }); // bytes
   const a = new PassThrough({ highWaterMark });
   const b = new PassThrough({ highWaterMark });

--- a/src/utils/streamPipeline.js
+++ b/src/utils/streamPipeline.js
@@ -1,5 +1,8 @@
 import pLimit from "p-limit";
-import { streamCsvRows } from "./csvStream.js";
+import Papa from "papaparse";
+import iconv from "iconv-lite";
+import crypto from "crypto";
+import { createFileTee } from "./csvStream.js";
 import sanitizeRow from "./sanitizeValue.js";
 import { insertBatchInTable, insertRegisterinTable } from "../model/tableModel.js";
 import { addAviso, addErro, addInfo } from "../middleware/errorHandler.js";
@@ -16,14 +19,9 @@ import {
  * @param {object} tiposFinal Tipos normalizados das colunas.
  * @param {object} opts Callbacks de progresso.
  */
-export async function streamPipeline(metadados, tiposFinal, opts = {}) {
-  console.log("[DEBUG] streamPipeline chamado")
-  const {
-    publishRead,
-    publishInsert,
-    onInsertStart,
-    onFlush,
-  } = opts;
+export async function streamPipeline(metadados, tiposFinal, opts = {}, pipelineOpts = {}) {
+  const { publishRead, publishInsert, onInsertStart, onFlush } = opts;
+  const { computeHash = true } = pipelineOpts;
 
   const {
     caminho_original: contexto,
@@ -32,7 +30,6 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}) {
     colunas_tabela: cols,
     encoding,
     delimiter,
-    total_linhas: total,
   } = metadados;
 
   const BATCH_ROWS_CAP = BATCH_SIZE;
@@ -75,7 +72,7 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}) {
     try {
       await insertBatchInTable(tabela, lote, cols, { skipUpdateClause: true });
       inseridosAteAgora += lote.length;
-      publishInsert?.(inseridosAteAgora, total);
+      publishInsert?.(inseridosAteAgora);
     } catch (e) {
       addAviso(
         `[BATCH] Falha no lote (${lote.length}). Fallback linha-a-linha. Motivo: ${e.message}`,
@@ -90,9 +87,9 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}) {
           fail++; addErro(`Erro ao inserir linha ${inseridosAteAgora + 1}: ${err.message}`, contexto);
         }
       }
-      publishInsert?.(inseridosAteAgora, total);
+      publishInsert?.(inseridosAteAgora);
     } finally {
-      addInfo(`[BATCH] Inseridos ${lote.length} linhas (até agora: ${inseridosAteAgora}/${total}).`, contexto);
+      addInfo(`[BATCH] Inseridos ${lote.length} linhas (até agora: ${inseridosAteAgora}).`, contexto);
     }
   }
 
@@ -107,14 +104,41 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}) {
     p.finally(() => inflight.delete(p));
   }
 
-  for await (const linhaOriginal of streamCsvRows(
-    contexto,
-    headersNorm,
-    encoding,
+  const { forHash, forParse } = createFileTee(contexto, { highWaterMark: HWM });
+  let hash;
+  if (computeHash) {
+    hash = crypto.createHash("sha256");
+    forHash.on("data", (chunk) => hash.update(chunk));
+  } else {
+    forHash.resume();
+  }
+
+  const input =
+    encoding === "latin1"
+      ? forParse.pipe(iconv.decodeStream("latin1"))
+      : (forParse.setEncoding("utf8"), forParse);
+  const parser = Papa.parse(Papa.NODE_STREAM_INPUT, {
+    header: false,
     delimiter,
-    { highWaterMark: HWM },
-  )) {
-    const linhaTipada = sanitizeRow(linhaOriginal, tiposFinal, contexto);
+    skipEmptyLines: "greedy",
+    dynamicTyping: false,
+  });
+  const stream = input.pipe(parser);
+  const headersLen = headersNorm.length;
+  let isFirstRow = true;
+
+  for await (const rowArray of stream) {
+    const row = Array.isArray(rowArray) ? rowArray : rowArray?.data || [];
+    if (isFirstRow) { isFirstRow = false; continue; }
+
+    const obj = {};
+    for (let i = 0; i < headersLen; i++) {
+      const h = headersNorm[i];
+      const v = row[i];
+      obj[h] = v == null ? null : typeof v === "string" ? v.trim() : v;
+    }
+
+    const linhaTipada = sanitizeRow(obj, tiposFinal, contexto);
     const rowBytes = approxRowBytes(linhaTipada);
 
     if (batch.length > 0 && (batch.length >= BATCH_ROWS_CAP || (batchBytes + rowBytes) > MAX_BATCH_BYTES)) {
@@ -130,17 +154,22 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}) {
     batch.push(linhaTipada);
     batchBytes += rowBytes;
     lidas++;
-    publishRead?.(lidas, total, batch.length);
+    publishRead?.(lidas);
   }
 
   await flushBatch();
   await Promise.all(inflight);
 
+  metadados.total_linhas = lidas;
+  if (computeHash && hash) {
+    metadados.hash = hash.digest("hex");
+  }
+
   return {
     erro: false,
-    total,
+    total: lidas,
     inseridos: inseridosAteAgora,
-    falhas: Math.max(0, total - inseridosAteAgora),
+    falhas: Math.max(0, lidas - inseridosAteAgora),
     mensagem: null,
   };
 }


### PR DESCRIPTION
## Summary
- add `PIPELINE_FAST_PATH` flag and wire controllers to build metadata from CSV header only
- compute file hash during streaming pipeline and remove second read
- check data overlap by date range derived from file path

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0899bcf0883248e40262fcf9ed925