### PR TITLE
feat: guardar tamanho e linhas do CSV com pré-check por metadados

### DIFF
--- a/sql/migrations/2025-09-10_add_file_meta_to_log_ingestao.sql
+++ b/sql/migrations/2025-09-10_add_file_meta_to_log_ingestao.sql
@@ -1,0 +1,6 @@
+ALTER TABLE log_ingestao
+  ADD COLUMN file_size_bytes BIGINT UNSIGNED NULL AFTER hash_arquivo,
+  ADD COLUMN total_linhas INT UNSIGNED NULL AFTER file_size_bytes;
+
+CREATE INDEX idx_log_ing_meta
+  ON log_ingestao (tabela_destino, file_size_bytes, total_linhas);

--- a/src/controller/createDataController.js
+++ b/src/controller/createDataController.js
@@ -1,4 +1,5 @@
 import path from "path";
+import { stat } from "fs/promises";
 import { analyzeCsv, readCsvHeader, normalizeHeadersOnce } from "../utils/csvStream.js";
 import { addAviso, addErro } from "../middleware/errorHandler.js";
 import { detectEncoding, detectDelimiter } from "../utils/prepareStreamByFilepath.js";
@@ -91,12 +92,19 @@ export default async function createDataController(filePath, action) {
 }
 
 export async function createFundamentalDocsController(filePath, action, contexto) {
-  return createMetadadosController(filePath, action)
-    .then((metadados) => {
-      const logData = createLogDataController(metadados, /*now*/ null);
-      return { metadados, logData };
-    })
-    .catch((e) => { addErro("Erro ao gerar os objetos fundamentais, metadados e logdata, erro: " + e.message, contexto ); throw e; });
+  try {
+    const metadados = await createMetadadosController(filePath, action);
+    const { size } = await stat(filePath);
+    metadados.file_size_bytes = size;
+    // total_linhas já preenchido em createMetadadosController
+    const logData = createLogDataController(metadados, /*now*/ null);
+    logData.file_size_bytes = metadados.file_size_bytes;
+    logData.total_linhas = metadados.total_linhas;
+    return { metadados, logData };
+  } catch (e) {
+    addErro("Erro ao gerar os objetos fundamentais, metadados e logdata, erro: " + e.message, contexto);
+    throw e;
+  }
 }
 
 export async function createMetadadosController(filePath, action) {
@@ -174,6 +182,8 @@ export function createLogDataController(m, now) {
     coluna_data: m.coluna_data,
     data_upload: now || new Date(), // reuse se vier de fora
     hash_arquivo: m.hash,
+    file_size_bytes: m.file_size_bytes ?? null,
+    total_linhas: m.total_linhas ?? null,
     caminho_original: m.caminho_truncado || truncarFilepath(m.caminho_original),
     sucesso: true,
     mensagem_erro: null,

--- a/src/controller/fluxoValidatorController.js
+++ b/src/controller/fluxoValidatorController.js
@@ -1,5 +1,5 @@
 import { addErro, addInfo } from "../middleware/errorHandler.js";
-import { getLogByData, getAllHashesFromTable } from "../model/logModel.js";
+import { getLogByData, getAllHashesFromTable, findLogByFileMeta } from "../model/logModel.js";
 import { existsAnyDataInRange } from "../model/tableModel.js";
 import { PIPELINE_FAST_PATH } from "../../config/index.js";
 
@@ -34,6 +34,24 @@ export default async function fluxoValidatorController(metadados, logData) {
 
   if (!hash) {
     addErro("Hash do arquivo não foi passado ao validador do fluxo.", contexto);
+  }
+
+  if (metadados?.file_size_bytes != null && metadados?.total_linhas != null) {
+    try {
+      const similar = await findLogByFileMeta({
+        tabela_destino: metadados.tabela,
+        file_size_bytes: metadados.file_size_bytes,
+        total_linhas: metadados.total_linhas,
+      });
+      if (similar) {
+        addInfo(
+          "[Validator] Meta match (size+lines) encontrado — provável duplicado; seguir com verificação por hash.",
+          contexto
+        );
+      }
+    } catch (e) {
+      addErro(`Erro ao buscar log por metadados: ${e.message}`, contexto);
+    }
   }
 
   const pLogs = getLogByData(metadados).catch((e) => {

--- a/src/model/logModel.js
+++ b/src/model/logModel.js
@@ -100,8 +100,8 @@ export async function getAllHashesFromTable(metadados) {
 // -----------------------------------------------------
 const INSERT_LOG_SQL = `
   INSERT INTO \`${schema}\`.log_ingestao
-  (tabela_destino, nome_arquivo, ano, mes, dia, coluna_data, data_upload, hash_arquivo, sucesso, mensagem_erro, caminho)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  (tabela_destino, nome_arquivo, ano, mes, dia, coluna_data, data_upload, hash_arquivo, file_size_bytes, total_linhas, sucesso, mensagem_erro, caminho)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `;
 
 export async function insertLog(logData) {
@@ -114,6 +114,8 @@ export async function insertLog(logData) {
     logData.coluna_data ?? null,
     logData.data_upload ?? new Date(),
     logData.hash_arquivo ?? null,
+    logData.file_size_bytes ?? null,
+    logData.total_linhas != null ? Number(logData.total_linhas) : null,
     logData.sucesso ? 1 : 0,
     logData.mensagem_erro ?? null,
     logData.caminho_original ?? null,
@@ -191,5 +193,34 @@ export async function getLogWithFilePath(filePath) {
     throw new Error(
       `[model get From banco] Erro ao encontrar log com base no caminho: ${e.message}`
     );
+  }
+}
+
+// -----------------------------------------------------
+// 7) Busca log por metadados básicos (tamanho + linhas)
+// -----------------------------------------------------
+const FIND_BY_META_SQL = `
+  SELECT id
+    FROM \`${schema}\`.log_ingestao
+   WHERE tabela_destino = ?
+     AND file_size_bytes <=> ?
+     AND total_linhas <=> ?
+   ORDER BY id DESC
+   LIMIT 1
+`;
+
+export async function findLogByFileMeta({ tabela_destino, file_size_bytes, total_linhas }) {
+  const params = [tabela_destino, file_size_bytes ?? null, total_linhas ?? null];
+  try {
+    const stmt = getStmt("FIND_BY_META", FIND_BY_META_SQL);
+    if (stmt) {
+      const ps = await stmt;
+      const [rows] = await ps.execute(params);
+      return rows && rows.length ? rows[0] : null;
+    }
+    const [rows] = await exec(FIND_BY_META_SQL, params);
+    return rows && rows.length ? rows[0] : null;
+  } catch (e) {
+    throw new Error(`[model find log meta] Erro ao buscar log por metadados: ${e.message}`);
   }
 }


### PR DESCRIPTION
## Summary
- store file_size_bytes and total_linhas in ingestion log
- populate metadata with file size and line count
- validate duplicates using size and line metadata before hash check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a457a8ac832489f45afc8b185168