### PR TITLE
fix: correct error context in createdHandler

### DIFF
--- a/src/controller/Handlers/createdHandler.js
+++ b/src/controller/Handlers/createdHandler.js
@@ -19,7 +19,13 @@ export default async function createdHandler(filePath, action) {
   // read fast-path flag (unused but kept for clarity)
   const useFastPath = PIPELINE_FAST_PATH;
 
-  if (!filePath) { addErro("caminho do arquivo não definido no handler, sem como identificar qual arquivo deu erro...", contexto); return; }
+  if (!filePath) {
+    addErro(
+      "caminho do arquivo não definido no handler, sem como identificar qual arquivo deu erro...",
+      filePath
+    );
+    return;
+  }
   let metadados, logData;
 
   try {


### PR DESCRIPTION
## Summary
- handle missing file path with proper context on created handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1db87026c8324b4fa5f87ae2069ad