### PR TITLE
Improve logger finalization and bootstrap

### DIFF
--- a/src/middleware/logger.js
+++ b/src/middleware/logger.js
@@ -5,6 +5,7 @@ import path from 'path';
 const loggers = new Map();
 const FLUSH_MS = Number(process.env.LOG_FLUSH_MS || 200);
 const FLUSH_LINES = Number(process.env.LOG_FLUSH_LINES || 20);
+const CLOSE_TIMEOUT_MS = Number(process.env.LOG_CLOSE_TIMEOUT_MS || 10000);
 
 export function fmtTimeNow() {
   return new Date().toISOString();
@@ -14,17 +15,56 @@ function getLogger(filePath) {
   return loggers.get(filePath);
 }
 
+function waitForDrain(stream) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    function cleanup() {
+      stream.off('drain', onDrain);
+      stream.off('error', onError);
+      stream.off('close', onClose);
+    }
+    function onDrain() {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    }
+    function onClose() {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    }
+    function onError(err) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err);
+    }
+
+    stream.once('drain', onDrain);
+    stream.once('error', onError);
+    stream.once('close', onClose);
+  });
+}
+
 async function flush(filePath) {
   const entry = loggers.get(filePath);
   if (!entry || entry.buffer.length === 0) return;
   const data = entry.buffer.join('');
   entry.buffer.length = 0;
-  if (!entry.stream.write(data)) {
-    await new Promise((resolve) => entry.stream.once('drain', resolve));
+  try {
+    if (!entry.stream.write(data)) {
+      await waitForDrain(entry.stream);
+    }
+  } catch (err) {
+    entry.stream.destroy?.(err);
+    throw err;
   }
 }
 
 export function startLogger(filePath) {
+  if (loggers.has(filePath)) return;
   const dir = path.join(path.dirname(filePath), 'loggers');
   fs.mkdirSync(dir, { recursive: true });
   const logPath = path.join(dir, `Logger_${path.parse(filePath).name}.txt`);
@@ -47,13 +87,77 @@ export async function logLine(filePath, level, msg) {
   }
 }
 
+function waitForStreamClose(stream) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    function cleanup() {
+      stream.off('finish', onFinish);
+      stream.off('close', onClose);
+      stream.off('error', onError);
+      if (timeoutId) clearTimeout(timeoutId);
+    }
+    const timeoutId = CLOSE_TIMEOUT_MS
+      ? setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          stream.destroy();
+          resolve();
+        }, CLOSE_TIMEOUT_MS)
+      : null;
+    function settle(err) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (err) reject(err);
+      else resolve();
+    }
+    function onFinish() {
+      settle();
+    }
+    function onClose() {
+      settle();
+    }
+    function onError(err) {
+      settle(err);
+    }
+
+    stream.once('finish', onFinish);
+    stream.once('close', onClose);
+    stream.once('error', onError);
+
+    try {
+      stream.end();
+    } catch (err) {
+      settle(err);
+    }
+  });
+}
+
 export async function endLogger(filePath) {
   const entry = loggers.get(filePath);
   if (!entry) return;
-  await flush(filePath);
-  await new Promise((resolve) => entry.stream.end(resolve));
-  clearInterval(entry.timer);
-  loggers.delete(filePath);
+  if (entry.endingPromise) return entry.endingPromise;
+
+  entry.endingPromise = (async () => {
+    clearInterval(entry.timer);
+    try {
+      await logLine(filePath, 'INFO', `==== END ${fmtTimeNow()} ====`);
+    } catch {}
+    try {
+      await flush(filePath);
+    } catch (err) {
+      entry.stream.destroy?.(err);
+      throw err;
+    }
+    try {
+      await waitForStreamClose(entry.stream);
+    } finally {
+      loggers.delete(filePath);
+    }
+  })();
+
+  return entry.endingPromise;
 }
 
 export async function appendLine(contexto, line) {

--- a/src/utils/bootStrapLogs.js
+++ b/src/utils/bootStrapLogs.js
@@ -1,4 +1,14 @@
+import { startLogger, logLine } from "../middleware/logger.js";
 import { silencePapaDuplicatesStart } from "./silencePapa.js";
 
+const GLOBAL_CONTEXT = "__global";
+
+try {
+  startLogger(GLOBAL_CONTEXT);
+  logLine(GLOBAL_CONTEXT, "info", "Logger global inicializado.").catch(() => {});
+} catch (err) {
+  console.error("[logger] Falha ao iniciar logger global:", err?.message || err);
+}
+
 // Ativa o silêncio global para os avisos de header duplicado do PapaParse
-silencePapaDuplicatesStart();   
+silencePapaDuplicatesStart();

--- a/src/utils/withFileLifecycle.js
+++ b/src/utils/withFileLifecycle.js
@@ -14,9 +14,14 @@ export async function withFileLifecycle(filePath, fn) {
   try {
     await fn();
   } finally {
-    await endLogger(filePath);
-    off();
-    clearAllErrors(filePath);
-    activeFiles.delete(filePath);
+    try {
+      await endLogger(filePath);
+    } catch (err) {
+      console.error(`[logger] Falha ao finalizar logger de ${filePath}:`, err?.message || err);
+    } finally {
+      off();
+      clearAllErrors(filePath);
+      activeFiles.delete(filePath);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- harden the batch logger by handling backpressure events, appending an explicit END marker and waiting for close with a timeout
- ensure the file lifecycle always releases resources even when logger shutdown fails
- bootstrap the global logger context during startup so watchdog messages are recorded

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c86cf343048324b32126ca51b8098c