### PR TITLE
Improve logging lifecycle and add global monitoring

### DIFF
--- a/src/controller/Handlers/createdHandler.js
+++ b/src/controller/Handlers/createdHandler.js
@@ -5,23 +5,29 @@ import fluxoValidatorController from "../fluxoValidatorController.js";
 import { manageInsertController } from "../managerDataController.js";
 import { PIPELINE_FAST_PATH } from "../../../config/index.js";
 import { withFileLifecycle } from "../../utils/withFileLifecycle.js";
+import { markJobComplete } from "../../utils/queueTracker.js";
 
-export default async function createdHandler(filePath, action) {
+export default async function createdHandler(filePath, action, job) {
   const useFastPath = PIPELINE_FAST_PATH; // kept for compatibility
   if (!filePath) {
     addErro(
       "caminho do arquivo não definido no handler, sem como identificar qual arquivo deu erro...",
       filePath
     );
+    if (job) {
+      markJobComplete(job, { success: false, message: "FilePath indefinido" });
+    }
     return;
   }
 
-  await withFileLifecycle(filePath, async () => {
-    let metadados, logData;
-    try {
-      const result = await createDataController(filePath, action);
-      ({ metadados, logData } = result || {});
-    } catch (e) {
+  await withFileLifecycle(
+    filePath,
+    async () => {
+      let metadados, logData;
+      try {
+        const result = await createDataController(filePath, action);
+        ({ metadados, logData } = result || {});
+      } catch (e) {
       addErro(`erro ao gerar os dados fundamentais, erro:${e.message}`, filePath);
       return;
     }
@@ -62,5 +68,7 @@ export default async function createdHandler(filePath, action) {
     } finally {
       await insertLog(logData);
     }
-  });
+    },
+    { job, action }
+  );
 }

--- a/src/controller/Handlers/deletedHandler.js
+++ b/src/controller/Handlers/deletedHandler.js
@@ -4,13 +4,15 @@ import { destinoByFilePath } from "../createDataController.js";
 import { managerDeleterController } from "../managerDataController.js";
 import { withFileLifecycle } from "../../utils/withFileLifecycle.js";
 
-export default async function deletedHandler(filePath, acao) {
-  await withFileLifecycle(filePath, async () => {
-    let logData = {};
-    try {
-      const destino = destinoByFilePath(filePath);
+export default async function deletedHandler(filePath, acao, job) {
+  await withFileLifecycle(
+    filePath,
+    async () => {
+      let logData = {};
       try {
-        logData = await getLogWithFilePath(filePath);
+        const destino = destinoByFilePath(filePath);
+        try {
+          logData = await getLogWithFilePath(filePath);
         if (!logData) {
           addErro(`Nenhum registro de log encontrado para ${filePath} logica de exclusão travada`, filePath);
           return;
@@ -37,5 +39,7 @@ export default async function deletedHandler(filePath, acao) {
     } catch (e) {
       addErro(`Erro no deletedHandler, erro: ${e.message}, ${e.stack}`, filePath);
     }
-  });
+    },
+    { job, action: acao }
+  );
 }

--- a/src/controller/managerDataController.js
+++ b/src/controller/managerDataController.js
@@ -6,6 +6,7 @@ import {
 } from "../utils/progressBar.js";
 
 import { addAviso, addErro, addInfo } from "../middleware/errorHandler.js";
+import { logActivity } from "../middleware/logger.js";
 import streamPipeline, {
   POOL_MAX,
   INSERT_MAX_CONCURRENT,
@@ -25,6 +26,7 @@ import {
   HIGH_WATERMARK_DEFAULT,
   LOW_WATERMARK_DEFAULT,
 } from "../../config/index.js";
+import { updateActiveJob } from "../utils/queueTracker.js";
 
 export async function manageInsertController(metadados, logData) {
   const contexto = metadados.caminho_original;
@@ -36,18 +38,24 @@ export async function manageInsertController(metadados, logData) {
     `Configuração: INSERT_MAX_CONCURRENT=${INSERT_MAX_CONCURRENT}, FILES_MAX_CONCURRENT=${FILES_MAX_CONCURRENT}, BATCH_SIZE=${BATCH_SIZE}, QUEUE_HIGH_WATERMARK=${HIGH_WATERMARK_DEFAULT}, QUEUE_LOW_WATERMARK=${LOW_WATERMARK_DEFAULT}`,
     contexto,
   );
+  void logActivity("info", "Preparação iniciada", { filePath: contexto });
+  updateActiveJob(contexto, { stage: "preparação", detail: "Coletando metadados" });
 
   // -------- Barra global: 0..100 (3 fases) --------
   const PHASES = { prep: 15, read: 45, insert: 40 }; // soma 100
   let phaseBase = 0;
   let phaseSpan = PHASES.prep;
   let lastPctAbs = 0;
+  const stageNames = { prep: "preparação", read: "leitura", insert: "inserção" };
+  let currentStageName = stageNames.prep;
 
   iniciarBarra(barraId, 100, nomeArquivo, metadados.tabela, metadados.ano);
 
   function setPhase(name) {
     phaseBase += phaseSpan;
     phaseSpan = PHASES[name];
+    currentStageName = stageNames[name] || name;
+    updateActiveJob(contexto, { stage: currentStageName });
   }
   function publish(percent0to1, statusText) {
     const abs = Math.max(0, Math.min(100, Math.floor(phaseBase + percent0to1 * phaseSpan)));
@@ -58,6 +66,12 @@ export async function manageInsertController(metadados, logData) {
     } else if (statusText) {
       atualizarBarra(barraId, 0, statusText);
     }
+    const progress = abs / 100;
+    updateActiveJob(contexto, {
+      progress,
+      stage: currentStageName,
+      detail: statusText || currentStageName,
+    });
   }
 
   try {
@@ -83,13 +97,16 @@ export async function manageInsertController(metadados, logData) {
     metadados.encoding = encoding;
     metadados.delimiter = delimiter;
     const headersNorm = metadados.colunas_json;
+    updateActiveJob(contexto, { detail: `Encoding ${encoding} | Delimitador ${delimiter}` });
 
     // Tipos esperados (schema + overrides)
     const schemaMap = await loadDecimalProfilesFromSchema(metadados.tabela);
     const tiposFinal = expandTiposWithSchema(metadados.tipos_esperados, schemaMap);
+    void logActivity("info", "Preparação concluída", { filePath: contexto });
 
     publish(1.0, "Preparação concluída");
     setPhase("read"); // 15..60%
+    void logActivity("info", "Leitura e validação iniciadas", { filePath: contexto });
 
     // -------- Valida dados e ação --------
     const total = metadados.total_linhas || 0;
@@ -112,21 +129,27 @@ export async function manageInsertController(metadados, logData) {
 
     if (validator === "cadastro" || validator === "substituir") {
       try {
+        void logActivity("info", "Removendo período anterior", { filePath: contexto });
         await deleteFromTable(metadados);
         const msg = validator === "cadastro"
           ? "[Delete dados] tabela limpa para reinserção cadastral"
           : "[Gerenciamento] substituição: período removido antes da reinserção";
         addInfo(msg, contexto);
+        void logActivity("info", "Remoção concluída", { filePath: contexto });
       } catch (e) {
         addErro(`Erro ao deletar antes da reinserção: ${e.message}`, contexto);
+        void logActivity("error", `Falha ao deletar período: ${e.message}`, { filePath: contexto });
         throw e;
       }
     } else if (validator === null) {
       addErro("Validação nula (dados inválidos ou sem coluna de data).", contexto);
+      void logActivity("warn", "Validação nula: dados inválidos", { filePath: contexto });
       return { erro: true, total, inseridos: 0, falhas: total, mensagem: "Validação nula" };
     }
 
     addInfo("Iniciando leitura e montagem de lotes...", contexto);
+    void logActivity("info", "Pipeline de streaming iniciado", { filePath: contexto });
+    updateActiveJob(contexto, { stage: "leitura", detail: "Stream iniciada", progress: lastPctAbs / 100 });
 
     try {
       const resultado = await streamPipeline(
@@ -149,10 +172,13 @@ export async function manageInsertController(metadados, logData) {
       }
 
       addInfo("Processo de inserção finalizado.", contexto);
+      void logActivity("info", "Pipeline de streaming concluído", { filePath: contexto });
+      updateActiveJob(contexto, { stage: "finalização", progress: 1, detail: "Processo concluído" });
 
       return resultado;
     } catch (e) {
       addErro(`Falha no pipeline de leitura/inserção: ${e.message}`, contexto);
+      void logActivity("error", `Falha no pipeline: ${e.message}`, { filePath: contexto });
       throw e;
     }
   } finally {
@@ -165,12 +191,15 @@ export async function managerDeleterController(logData) {
   const contexto = logData.caminho_original;
 
   try {
+    void logActivity("info", "Fluxo de deleção iniciado", { filePath: contexto });
     const res = await deleteFromTable(logData);
     const removidos = res?.affectedRows ?? res?.affected_rows ?? 0;
     addInfo( `[DELETE] Removidos ${removidos} registros de ${logData.tabela || logData.tabela_destino}.`, contexto );
+    void logActivity("info", `Fluxo de deleção concluído (${removidos} registros)`, { filePath: contexto });
     return { erro: false, removidos };
   } catch (e) {
     addErro( `Erro ao deletar período no banco pós exclusão do arquivo, erro: ${e.message}`, contexto);
+    void logActivity("error", `Erro durante deleção: ${e.message}`, { filePath: contexto });
     return { erro: true, mensagem: e.message };
   }
 }

--- a/src/middleware/logger.js
+++ b/src/middleware/logger.js
@@ -1,176 +1,341 @@
-// New logger implementing batch write with backpressure
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
 const loggers = new Map();
+
 const FLUSH_MS = Number(process.env.LOG_FLUSH_MS || 200);
-const FLUSH_LINES = Number(process.env.LOG_FLUSH_LINES || 20);
-const CLOSE_TIMEOUT_MS = Number(process.env.LOG_CLOSE_TIMEOUT_MS || 10000);
+const FLUSH_LINES = Number(process.env.LOG_FLUSH_LINES || 100);
+const CLOSE_TIMEOUT_MS = Number(process.env.LOG_CLOSE_TIMEOUT_MS || 5000);
+
+const LOG_ROOT = path.resolve(process.cwd(), "logs");
+const ACTIVITY_LOG_KEY = "__activity__";
+const ACTIVITY_LOG_PATH = path.join(LOG_ROOT, "_activity.txt");
+
+fs.mkdirSync(LOG_ROOT, { recursive: true });
 
 export function fmtTimeNow() {
   return new Date().toISOString();
 }
 
-function getLogger(filePath) {
+function formatLine(level, msg) {
+  return `[${fmtTimeNow()}][${String(level ?? "info").toUpperCase()}] ${msg}\n`;
+}
+
+function getEntry(filePath) {
   return loggers.get(filePath);
 }
 
 function waitForDrain(stream) {
   return new Promise((resolve, reject) => {
     let settled = false;
-    function cleanup() {
-      stream.off('drain', onDrain);
-      stream.off('error', onError);
-      stream.off('close', onClose);
-    }
-    function onDrain() {
+    const cleanup = () => {
+      stream.off("drain", onDrain);
+      stream.off("error", onError);
+      stream.off("close", onClose);
+    };
+    const onDrain = () => {
       if (settled) return;
       settled = true;
       cleanup();
       resolve();
-    }
-    function onClose() {
+    };
+    const onClose = () => {
       if (settled) return;
       settled = true;
       cleanup();
       resolve();
-    }
-    function onError(err) {
+    };
+    const onError = (err) => {
       if (settled) return;
       settled = true;
       cleanup();
       reject(err);
-    }
+    };
 
-    stream.once('drain', onDrain);
-    stream.once('error', onError);
-    stream.once('close', onClose);
+    stream.once("drain", onDrain);
+    stream.once("error", onError);
+    stream.once("close", onClose);
   });
 }
 
-async function flush(filePath) {
-  const entry = loggers.get(filePath);
-  if (!entry || entry.buffer.length === 0) return;
-  const data = entry.buffer.join('');
-  entry.buffer.length = 0;
-  try {
-    if (!entry.stream.write(data)) {
-      await waitForDrain(entry.stream);
-    }
-  } catch (err) {
-    entry.stream.destroy?.(err);
-    throw err;
-  }
-}
-
-export function startLogger(filePath) {
-  if (loggers.has(filePath)) return;
-  const dir = path.join(path.dirname(filePath), 'loggers');
+function defaultLogPath(filePath) {
+  const dir = path.join(path.dirname(filePath), "loggers");
+  const base = path.parse(filePath).name || path.basename(filePath) || "log";
   fs.mkdirSync(dir, { recursive: true });
-  const logPath = path.join(dir, `Logger_${path.parse(filePath).name}.txt`);
-  const stream = fs.createWriteStream(logPath, { flags: 'a', highWaterMark: 1024 * 1024 });
-  const buffer = [];
-  const timer = setInterval(() => {
-    flush(filePath).catch(() => {});
-  }, FLUSH_MS);
-  timer.unref?.();
-  loggers.set(filePath, { stream, buffer, timer });
-  logLine(filePath, 'INFO', `==== BEGIN ${fmtTimeNow()} ====`).catch(() => {});
+  return path.join(dir, `Logger_${base}.txt`);
 }
 
-export async function logLine(filePath, level, msg) {
-  const entry = loggers.get(filePath);
-  if (!entry) return;
-  entry.buffer.push(`[${fmtTimeNow()}][${level.toUpperCase()}] ${msg}\n`);
-  if (entry.buffer.length >= FLUSH_LINES) {
-    await flush(filePath);
-  }
-}
+function waitForStreamToEnd(stream) {
+  let settled = false;
+  let cleanup = () => {};
+  let timeoutId;
 
-function waitForStreamClose(stream) {
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    function cleanup() {
-      stream.off('finish', onFinish);
-      stream.off('close', onClose);
-      stream.off('error', onError);
-      if (timeoutId) clearTimeout(timeoutId);
-    }
-    const timeoutId = CLOSE_TIMEOUT_MS
-      ? setTimeout(() => {
-          if (settled) return;
-          settled = true;
-          cleanup();
-          stream.destroy();
-          resolve();
-        }, CLOSE_TIMEOUT_MS)
-      : null;
-    function settle(err) {
+  const eventsPromise = new Promise((resolve) => {
+    const settle = (value) => {
       if (settled) return;
       settled = true;
       cleanup();
-      if (err) reject(err);
-      else resolve();
-    }
-    function onFinish() {
-      settle();
-    }
-    function onClose() {
-      settle();
-    }
-    function onError(err) {
-      settle(err);
-    }
+      resolve(value);
+    };
 
-    stream.once('finish', onFinish);
-    stream.once('close', onClose);
-    stream.once('error', onError);
+    const onFinish = () => settle({ status: "finish" });
+    const onClose = () => settle({ status: "close" });
+    const onError = (error) => settle({ status: "error", error });
 
-    try {
-      stream.end();
-    } catch (err) {
-      settle(err);
+    cleanup = () => {
+      stream.off("finish", onFinish);
+      stream.off("close", onClose);
+      stream.off("error", onError);
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+
+    stream.once("finish", onFinish);
+    stream.once("close", onClose);
+    stream.once("error", onError);
+  });
+
+  const timeoutPromise = new Promise((resolve) => {
+    timeoutId = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve({ status: "timeout" });
+    }, CLOSE_TIMEOUT_MS);
+    timeoutId.unref?.();
+  });
+
+  return Promise.race([eventsPromise, timeoutPromise]);
+}
+
+export function startLogger(filePath, options = {}) {
+  if (!filePath) return null;
+  if (loggers.has(filePath)) return loggers.get(filePath);
+
+  const {
+    logPath: forcedPath,
+    flushIntervalMs = FLUSH_MS,
+    highWaterMark = 1024 * 256,
+    disableBeginLine = false,
+    displayName,
+  } = options;
+
+  const logPath = forcedPath || defaultLogPath(filePath);
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+
+  const stream = fs.createWriteStream(logPath, {
+    flags: "a",
+    highWaterMark,
+  });
+
+  const entry = {
+    filePath,
+    logPath,
+    stream,
+    buffer: [],
+    timer: null,
+    inFlush: false,
+    flushPromise: null,
+    closing: false,
+    ended: false,
+    endPromise: null,
+    displayName: displayName || path.basename(filePath) || filePath,
+  };
+
+  stream.on("error", (err) => {
+    if (!entry.ended) {
+      entry.ended = true;
+      console.error(`[logger] erro no stream (${entry.displayName}):`, err?.message || err);
     }
   });
+
+  stream.on("close", () => {
+    entry.ended = true;
+  });
+
+  if (flushIntervalMs > 0) {
+    const timer = setInterval(() => {
+      flush(filePath).catch((err) => {
+        console.error(`[logger] flush falhou (${entry.displayName}):`, err?.message || err);
+      });
+    }, flushIntervalMs);
+    timer.unref?.();
+    entry.timer = timer;
+  }
+
+  loggers.set(filePath, entry);
+
+  if (!disableBeginLine) {
+    void logLine(filePath, "info", `==== BEGIN ${entry.displayName} ====`);
+  }
+
+  return entry;
+}
+
+export async function logLine(filePath, level, msg) {
+  const entry = getEntry(filePath);
+  if (!entry || entry.closing || entry.ended) return false;
+
+  entry.buffer.push(formatLine(level, msg));
+  if (entry.buffer.length >= FLUSH_LINES) {
+    await flush(filePath);
+  }
+  return true;
+}
+
+export async function flush(filePath) {
+  const entry = getEntry(filePath);
+  if (!entry) return;
+
+  if (entry.ended || entry.stream.destroyed) {
+    entry.buffer.length = 0;
+    return;
+  }
+
+  if (entry.inFlush && entry.flushPromise) {
+    try {
+      await entry.flushPromise;
+    } catch {}
+    if (!entry.buffer.length) return;
+  }
+
+  if (entry.buffer.length === 0) return;
+
+  const chunk = entry.buffer.join("");
+  entry.buffer.length = 0;
+
+  entry.inFlush = true;
+  const flushPromise = (async () => {
+    try {
+      if (!entry.stream.writable || entry.stream.destroyed || entry.ended) return;
+      if (!entry.stream.write(chunk)) {
+        await waitForDrain(entry.stream);
+      }
+    } catch (err) {
+      console.error(`[logger] erro ao escrever (${entry.displayName}):`, err?.message || err);
+      try {
+        entry.stream.destroy?.(err);
+      } catch {}
+      entry.ended = true;
+    } finally {
+      entry.inFlush = false;
+      if (entry.flushPromise === flushPromise) {
+        entry.flushPromise = null;
+      }
+    }
+  })();
+
+  entry.flushPromise = flushPromise;
+  await flushPromise;
+}
+
+async function finalizeStream(entry) {
+  if (!entry || entry.ended || entry.stream.destroyed) {
+    entry.ended = true;
+    return;
+  }
+
+  try {
+    entry.stream.end();
+  } catch (err) {
+    console.error(`[logger] stream.end falhou (${entry.displayName}):`, err?.message || err);
+    entry.ended = true;
+    return;
+  }
+
+  const result = await waitForStreamToEnd(entry.stream);
+  if (result.status === "error") {
+    console.error(`[logger] erro ao finalizar stream (${entry.displayName}):`, result.error?.message || result.error);
+  } else if (result.status === "timeout") {
+    console.error(`[logger] timeout ao finalizar stream (${entry.displayName})`);
+    try {
+      entry.stream.destroy?.();
+    } catch {}
+  }
+
+  entry.ended = true;
 }
 
 export async function endLogger(filePath) {
-  const entry = loggers.get(filePath);
+  const entry = getEntry(filePath);
   if (!entry) return;
-  if (entry.endingPromise) return entry.endingPromise;
 
-  entry.endingPromise = (async () => {
+  if (entry.endPromise) return entry.endPromise;
+
+  entry.closing = true;
+  if (entry.timer) {
     clearInterval(entry.timer);
-    try {
-      await logLine(filePath, 'INFO', `==== END ${fmtTimeNow()} ====`);
-    } catch {}
-    try {
-      await flush(filePath);
-    } catch (err) {
-      entry.stream.destroy?.(err);
-      throw err;
+    entry.timer = null;
+  }
+
+  entry.endPromise = (async () => {
+    if (entry.inFlush && entry.flushPromise) {
+      try {
+        await entry.flushPromise;
+      } catch (err) {
+        console.error(`[logger] flush pendente falhou (${entry.displayName}):`, err?.message || err);
+      }
     }
+
+    if (!entry.ended && !entry.stream.destroyed) {
+      entry.buffer.push(formatLine("info", `==== END ${entry.displayName} ====`));
+      try {
+        await flush(filePath);
+      } catch (err) {
+        console.error(`[logger] flush final falhou (${entry.displayName}):`, err?.message || err);
+      }
+    }
+
     try {
-      await waitForStreamClose(entry.stream);
+      await finalizeStream(entry);
+    } catch (err) {
+      console.error(`[logger] finalizeStream falhou (${entry.displayName}):`, err?.message || err);
     } finally {
+      entry.ended = true;
       loggers.delete(filePath);
     }
   })();
 
-  return entry.endingPromise;
-}
-
-export async function appendLine(contexto, line) {
-  // compatibility wrapper for old API
-  await logLine(contexto, 'INFO', line.trim());
+  return entry.endPromise;
 }
 
 export async function endAllLoggers() {
-  const promises = [];
-  for (const key of Array.from(loggers.keys())) {
-    promises.push(endLogger(key));
+  for (const [filePath] of Array.from(loggers.entries())) {
+    try {
+      await endLogger(filePath);
+    } catch (err) {
+      console.error(`[logger] falha ao encerrar ${filePath}:`, err?.message || err);
+    }
   }
-  await Promise.all(promises);
 }
 
-export default { startLogger, logLine, endLogger };
+export async function appendLine(contexto, line) {
+  await logLine(contexto, "info", line.trim());
+}
+
+function ensureActivityLogger() {
+  if (!loggers.has(ACTIVITY_LOG_KEY)) {
+    startLogger(ACTIVITY_LOG_KEY, {
+      logPath: ACTIVITY_LOG_PATH,
+      displayName: "_activity",
+    });
+  }
+}
+
+export function logActivity(level, message, { filePath, action } = {}) {
+  ensureActivityLogger();
+  const segments = [];
+  if (filePath) segments.push(path.basename(filePath));
+  if (action) segments.push(action);
+  const prefix = segments.length ? `[${segments.join(" | ")}] ` : "";
+  return logLine(ACTIVITY_LOG_KEY, level, `${prefix}${message}`);
+}
+
+export default {
+  startLogger,
+  logLine,
+  flush,
+  endLogger,
+  endAllLoggers,
+  logActivity,
+  fmtTimeNow,
+};

--- a/src/monitoring.js
+++ b/src/monitoring.js
@@ -13,6 +13,11 @@ import { startWatchdog } from "./monitoring/watchdog.js";
 import { setupGracefulShutdown } from "./utils/gracefulShutdown.js";
 import { endAllLoggers } from "./middleware/logger.js";
 import { shutdownPool } from "../config/dbPool.js";
+import {
+  enqueueFileJob,
+  updateDebounceSize,
+  updateMetrics as updateQueueMetrics,
+} from "./utils/queueTracker.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const limit = pLimit(FILES_MAX_CONCURRENT);
@@ -30,12 +35,15 @@ function runWithDebounce(filePath, acao, handler) {
       const fileSizeMB = stats.size / (1024 * 1024);
       if (fileSizeMB >= 200) chosen = bigLimit;
     } catch {}
-    chosen(() => handler(filePath, acao)).catch((e) => {
+    const job = enqueueFileJob(filePath, acao);
+    chosen(() => handler(filePath, acao, job)).catch((e) => {
       console.log(`[monitoramento] Erro ao processar arquivo cujo path é: ${filePath}, erro: ${e.message}`);
     });
     debounceTimers.delete(filePath);
+    updateDebounceSize(debounceTimers.size);
   }, 500);
   debounceTimers.set(filePath, { timer, ts: Date.now() });
+  updateDebounceSize(debounceTimers.size);
 }
 
 function purgeDebounceTimers() {
@@ -46,6 +54,7 @@ function purgeDebounceTimers() {
       debounceTimers.delete(fp);
     }
   }
+  updateDebounceSize(debounceTimers.size);
 }
 const purgeInterval = setInterval(purgeDebounceTimers, 10 * 60 * 1000);
 purgeInterval.unref?.();
@@ -101,7 +110,10 @@ export async function startMonitoring() {
     debounceTimersSize: debounceTimers.size,
     memoryGuardListeners: memoryGuard.listenerCount(),
     lastProgressTs: pipelineMetrics.lastProgressTs,
+    filesMaxConcurrent: FILES_MAX_CONCURRENT,
   }));
+
+  updateQueueMetrics({ filesMaxConcurrent: FILES_MAX_CONCURRENT });
 
   setupGracefulShutdown({
     watcher,

--- a/src/monitoring/watchdog.js
+++ b/src/monitoring/watchdog.js
@@ -1,11 +1,23 @@
-import { logLine } from "../middleware/logger.js";
+import { logActivity } from "../middleware/logger.js";
+import { updateMetrics as updateQueueMetrics, updateMemoryGuardListeners } from "../utils/queueTracker.js";
 
 export function startWatchdog(getMetrics, intervalMs = 60000, stallMs = Number(process.env.STALL_MS || 5 * 60 * 1000)) {
   const interval = setInterval(() => {
     const m = getMetrics();
-    logLine("__global", "info", `[watchdog] files=${m.activeFiles} pending=${m.pendingBatches} inflight=${m.inFlightInserts} debounce=${m.debounceTimersSize} listeners=${m.memoryGuardListeners}`);
-    if (Date.now() - m.lastProgressTs > stallMs && m.inFlightInserts > 0) {
-      logLine("__global", "warn", "[watchdog] possível stall detectado");
+    updateQueueMetrics({
+      pendingBatches: m.pendingBatches,
+      inFlightInserts: m.inFlightInserts,
+      lastProgressTs: m.lastProgressTs,
+      activeFiles: m.activeFiles,
+      filesMaxConcurrent: m.filesMaxConcurrent,
+    });
+    updateMemoryGuardListeners(m.memoryGuardListeners);
+
+    if (Date.now() - m.lastProgressTs > stallMs && (m.pendingBatches > 0 || m.inFlightInserts > 0)) {
+      void logActivity(
+        "warn",
+        `Watchdog: possível stall detectado (pending=${m.pendingBatches}, inflight=${m.inFlightInserts})`
+      );
     }
   }, intervalMs);
   interval.unref?.();

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,31 @@ import "../src/utils/bootStrapLogs.js";
 import express from "express";
 import { startMonitoring } from "./monitoring.js";
 import { getPool, query, shutdownPool } from "../config/dbPool.js";
+import { logActivity } from "./middleware/logger.js";
+
+function describeError(err) {
+  if (err instanceof Error) {
+    return err.stack || err.message;
+  }
+  if (typeof err === "object") {
+    try {
+      return JSON.stringify(err);
+    } catch {}
+  }
+  return String(err);
+}
+
+process.on("unhandledRejection", (reason) => {
+  const detail = describeError(reason);
+  console.error("[process] Unhandled rejection:", detail);
+  void logActivity("error", `Unhandled rejection: ${detail}`);
+});
+
+process.on("uncaughtException", (err) => {
+  const detail = describeError(err);
+  console.error("[process] Uncaught exception:", detail);
+  void logActivity("error", `Uncaught exception: ${detail}`);
+});
 
 const app = express();
 const port = 3000;

--- a/src/utils/bootStrapLogs.js
+++ b/src/utils/bootStrapLogs.js
@@ -1,4 +1,4 @@
-import { startLogger, logLine } from "../middleware/logger.js";
+import { startLogger, logLine, logActivity } from "../middleware/logger.js";
 import { silencePapaDuplicatesStart } from "./silencePapa.js";
 
 const GLOBAL_CONTEXT = "__global";
@@ -6,6 +6,7 @@ const GLOBAL_CONTEXT = "__global";
 try {
   startLogger(GLOBAL_CONTEXT);
   logLine(GLOBAL_CONTEXT, "info", "Logger global inicializado.").catch(() => {});
+  logActivity("info", "Logger de atividade inicializado.").catch(() => {});
 } catch (err) {
   console.error("[logger] Falha ao iniciar logger global:", err?.message || err);
 }

--- a/src/utils/gracefulShutdown.js
+++ b/src/utils/gracefulShutdown.js
@@ -1,8 +1,9 @@
-import { logLine } from "../middleware/logger.js";
+import { logLine, logActivity } from "../middleware/logger.js";
 
 export function setupGracefulShutdown({ watcher, pool, logManager, timers = [] }) {
   async function shutdown() {
     try { logLine("__global", "info", "iniciando shutdown..."); } catch {}
+    try { void logActivity("info", "Shutdown iniciado"); } catch {}
     try { await watcher?.close?.(); } catch {}
     try { await logManager?.endAll?.(); } catch {}
     try { await pool?.end?.(); } catch {}

--- a/src/utils/queueTracker.js
+++ b/src/utils/queueTracker.js
@@ -1,0 +1,260 @@
+import fs from "fs";
+import path from "path";
+import { fmtTimeNow } from "../middleware/logger.js";
+
+const LOG_ROOT = path.resolve(process.cwd(), "logs");
+const QUEUE_LOG_PATH = path.join(LOG_ROOT, "_queue.txt");
+const MAX_COMPLETED = 20;
+
+fs.mkdirSync(LOG_ROOT, { recursive: true });
+
+const state = {
+  pending: [],
+  active: new Map(),
+  fileToJob: new Map(),
+  completed: [],
+  debounceSize: 0,
+  memoryGuardListeners: 0,
+  metrics: {
+    pendingBatches: 0,
+    inFlightInserts: 0,
+    lastProgressTs: Date.now(),
+    activeFiles: 0,
+    filesMaxConcurrent: null,
+  },
+};
+
+let writeChain = Promise.resolve();
+let snapshotScheduled = false;
+
+function scheduleSnapshot() {
+  if (snapshotScheduled) return;
+  snapshotScheduled = true;
+  queueMicrotask(() => {
+    snapshotScheduled = false;
+    const snapshot = buildSnapshot();
+    writeChain = writeChain
+      .catch(() => {})
+      .then(() => fs.promises.writeFile(QUEUE_LOG_PATH, snapshot, "utf8"))
+      .catch((err) => {
+        console.error(`[queue] falha ao escrever snapshot:`, err?.message || err);
+      });
+  });
+}
+
+function createJobId() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return "0s";
+  const sec = Math.floor(ms / 1000);
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function buildSnapshot() {
+  const now = Date.now();
+  const lines = [];
+  const filesMax = state.metrics.filesMaxConcurrent ?? "n/a";
+  const lastProgressAgo = state.metrics.lastProgressTs
+    ? `${Math.max(0, now - state.metrics.lastProgressTs)}ms`
+    : "n/a";
+
+  lines.push(`Snapshot: ${fmtTimeNow()}`);
+  lines.push(`FILES_MAX_CONCURRENT=${filesMax}`);
+  lines.push("");
+
+  lines.push(`Ativos (${state.active.size}):`);
+  if (state.active.size === 0) {
+    lines.push("  - nenhum arquivo em processamento");
+  } else {
+    for (const { job, progress, stage, detail, startedAt } of state.active.values()) {
+      const pct = Number.isFinite(progress) ? `${Math.max(0, Math.min(100, progress * 100)).toFixed(1)}%` : "n/a";
+      const base = path.basename(job.filePath || job.id || "arquivo");
+      const elapsed = startedAt ? formatDuration(now - startedAt) : "-";
+      const detailText = detail ? ` | ${detail}` : "";
+      lines.push(`  - ${base} (${job.action || "?"}) :: ${stage || "iniciando"} :: ${pct}${detailText} :: ${elapsed}`);
+    }
+  }
+  lines.push("");
+
+  lines.push(`Pendentes (${state.pending.length}):`);
+  if (state.pending.length === 0) {
+    lines.push("  - fila vazia");
+  } else {
+    for (const job of state.pending) {
+      const waited = job.enqueuedAt ? formatDuration(now - job.enqueuedAt) : "-";
+      const base = path.basename(job.filePath || job.id || "arquivo");
+      lines.push(`  - ${base} (${job.action || "?"}) :: aguardando há ${waited}`);
+    }
+  }
+  lines.push("");
+
+  const completed = state.completed.slice(0, MAX_COMPLETED);
+  lines.push(`Concluídos (últimos ${completed.length}):`);
+  if (completed.length === 0) {
+    lines.push("  - nenhum histórico disponível");
+  } else {
+    for (const item of completed) {
+      const base = path.basename(item.job.filePath || item.job.id || "arquivo");
+      const duration = item.job.startedAt && item.finishedAt
+        ? formatDuration(item.finishedAt - item.job.startedAt)
+        : "-";
+      const status = item.success ? "ok" : `erro: ${item.message || ""}`.trim();
+      const finishedStamp = item.finishedAt
+        ? new Date(item.finishedAt).toISOString()
+        : fmtTimeNow();
+      lines.push(`  - ${finishedStamp} :: ${base} (${item.job.action || "?"}) :: ${status} :: ${duration}`);
+    }
+  }
+  lines.push("");
+
+  lines.push(
+    `debounceTimers=${state.debounceSize} | memoryGuardListeners=${state.memoryGuardListeners} | activeFiles=${state.metrics.activeFiles}`
+  );
+  lines.push(
+    `pendingBatches=${state.metrics.pendingBatches} | inFlight=${state.metrics.inFlightInserts} | lastProgressAgo=${lastProgressAgo}`
+  );
+
+  return `${lines.join("\n")}\n`;
+}
+
+function removePending(jobId) {
+  const idx = state.pending.findIndex((j) => j.id === jobId);
+  if (idx >= 0) {
+    state.pending.splice(idx, 1);
+  }
+}
+
+export function enqueueFileJob(filePath, action) {
+  const job = {
+    id: createJobId(),
+    filePath,
+    action,
+    enqueuedAt: Date.now(),
+  };
+  state.pending.push(job);
+  scheduleSnapshot();
+  return job;
+}
+
+export function ensureJob(job, filePath, action) {
+  if (job && job.id) {
+    if (!job.filePath) job.filePath = filePath;
+    if (!job.action && action) job.action = action;
+    return job;
+  }
+  return {
+    id: createJobId(),
+    filePath,
+    action,
+    enqueuedAt: Date.now(),
+    orphan: true,
+  };
+}
+
+export function markJobActive(job, info = {}) {
+  if (!job || !job.id) return job;
+  removePending(job.id);
+
+  const startedAt = Date.now();
+  job.startedAt = job.startedAt || startedAt;
+  const record = {
+    job,
+    stage: info.stage || "iniciando",
+    progress: typeof info.progress === "number" ? info.progress : 0,
+    detail: info.detail || "",
+    startedAt: job.startedAt,
+    lastUpdate: Date.now(),
+  };
+  state.active.set(job.id, record);
+  state.fileToJob.set(job.filePath, job.id);
+  state.metrics.activeFiles = state.active.size;
+  scheduleSnapshot();
+  return job;
+}
+
+export function updateActiveJob(filePath, patch = {}) {
+  if (!filePath) return;
+  const jobId = state.fileToJob.get(filePath);
+  if (!jobId) return;
+  const record = state.active.get(jobId);
+  if (!record) return;
+
+  if (typeof patch.progress === "number" && Number.isFinite(patch.progress)) {
+    record.progress = Math.max(0, Math.min(1, patch.progress));
+  }
+  if (typeof patch.stage === "string") {
+    record.stage = patch.stage;
+  }
+  if (typeof patch.detail === "string") {
+    record.detail = patch.detail;
+  }
+  record.lastUpdate = Date.now();
+  scheduleSnapshot();
+}
+
+export function markJobComplete(job, result = {}) {
+  if (!job || !job.id) return;
+
+  removePending(job.id);
+  const record = state.active.get(job.id);
+  state.active.delete(job.id);
+  state.fileToJob.delete(job.filePath);
+  state.metrics.activeFiles = state.active.size;
+
+  const finishedAt = Date.now();
+  job.finishedAt = finishedAt;
+  const success = result.success !== false && !result.error;
+  const message = result.message || result.error?.message || result.error || null;
+
+  state.completed.unshift({
+    job,
+    finishedAt,
+    success,
+    message: typeof message === "string" ? message : null,
+  });
+  if (state.completed.length > MAX_COMPLETED) {
+    state.completed.length = MAX_COMPLETED;
+  }
+
+  scheduleSnapshot();
+}
+
+export function updateDebounceSize(size) {
+  state.debounceSize = size;
+  scheduleSnapshot();
+}
+
+export function updateMemoryGuardListeners(count) {
+  state.memoryGuardListeners = count;
+  scheduleSnapshot();
+}
+
+export function updateMetrics(metrics = {}) {
+  Object.assign(state.metrics, metrics);
+  scheduleSnapshot();
+}
+
+export function getJobState(filePath) {
+  const jobId = state.fileToJob.get(filePath);
+  if (!jobId) return null;
+  return state.active.get(jobId) || null;
+}
+
+export default {
+  enqueueFileJob,
+  ensureJob,
+  markJobActive,
+  markJobComplete,
+  updateActiveJob,
+  updateDebounceSize,
+  updateMemoryGuardListeners,
+  updateMetrics,
+  getJobState,
+};

--- a/src/utils/streamPipeline.js
+++ b/src/utils/streamPipeline.js
@@ -18,6 +18,8 @@ import {
   HIGH_WATERMARK_DEFAULT,
   LOW_WATERMARK_DEFAULT,
 } from "../../config/index.js";
+import { logActivity } from "../middleware/logger.js";
+import { updateActiveJob } from "./queueTracker.js";
 
 const CPU = Math.max(1, os.cpus()?.length ?? 1);
 const pool = await getPool();
@@ -127,17 +129,22 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}, pipelineO
     if (!insertPhaseStarted) {
       onInsertStart?.();
       insertPhaseStarted = true;
+      updateActiveJob(contexto, { stage: "inserção", detail: "Inserções iniciadas" });
     }
+    void logActivity("info", `Inserindo lote (${lote.length} linhas)`, { filePath: contexto });
+    updateActiveJob(contexto, { detail: `Inserindo lote (${lote.length})` });
     try {
       await insertBatchFn(tabela, lote, cols, { skipUpdateClause: true });
       inseridosAteAgora += lote.length;
       publishInsert?.(inseridosAteAgora);
       metrics.lastProgressTs = Date.now();
+      void logActivity("info", `Lote concluído (${lote.length} linhas)`, { filePath: contexto });
     } catch (e) {
       addAviso(
         `[BATCH] Falha no lote (${lote.length}). Fallback linha-a-linha. Motivo: ${e.message}`,
         contexto,
       );
+      void logActivity("warn", `Fallback para inserção linha-a-linha: ${e.message}`, { filePath: contexto });
       let ok = 0, fail = 0;
       for (const row of lote) {
         try {
@@ -147,6 +154,7 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}, pipelineO
           fail++; addErro(`Erro ao inserir linha ${inseridosAteAgora + 1}: ${err.message}`, contexto);
         }
       }
+      updateActiveJob(contexto, { detail: `Fallback linha-a-linha (ok=${ok}, fail=${fail})` });
       publishInsert?.(inseridosAteAgora);
       metrics.lastProgressTs = Date.now();
     } finally {
@@ -178,11 +186,13 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}, pipelineO
         inflight.delete(p);
         metrics.pendingBatches--;
         metrics.inFlightInserts = inflight.size;
+        updateActiveJob(contexto, { detail: `Lotes em voo: ${inflight.size}` });
       });
     addInfo(
       `[FLUSH] inflight_inserts=${inflight.size}, batch_len=${lote.length}, approx_bytes=${loteBytes}`,
       contexto,
     );
+    updateActiveJob(contexto, { detail: `Enviando lote (${lote.length} linhas)` });
   }
 
   const { forHash, forParse } = createFileTee(contexto, { highWaterMark: HWM });
@@ -251,6 +261,9 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}, pipelineO
     `[STATS] tempo_medio_lote=${avgMs.toFixed(2)}ms, pico_inflight=${maxInflight}`,
     contexto,
   );
+  void logActivity("info", `[STATS] tempo_medio_lote=${avgMs.toFixed(2)}ms, pico_inflight=${maxInflight}`, {
+    filePath: contexto,
+  });
 
   metadados.total_linhas = lidas;
   let hex = null;

--- a/src/utils/withFileLifecycle.js
+++ b/src/utils/withFileLifecycle.js
@@ -1,18 +1,48 @@
-import { startLogger, endLogger } from "../middleware/logger.js";
+import { startLogger, endLogger, logActivity } from "../middleware/logger.js";
 import { memoryGuard } from "./memoryGuard.js";
 import { clearAllErrors } from "../middleware/errorHandler.js";
+import {
+  ensureJob,
+  markJobActive,
+  markJobComplete,
+  updateActiveJob,
+  updateMemoryGuardListeners,
+} from "./queueTracker.js";
 
 const activeFiles = new Set();
 export function getActiveFilesCount() {
   return activeFiles.size;
 }
 
-export async function withFileLifecycle(filePath, fn) {
+export async function withFileLifecycle(filePath, fn, lifecycleOpts = {}) {
   startLogger(filePath);
   activeFiles.add(filePath);
+
+  const { job: rawJob, action } = lifecycleOpts;
+  const job = markJobActive(
+    ensureJob(rawJob, filePath, action),
+    { stage: "inicializando", progress: 0, detail: action ? `Ação: ${action}` : "Preparando" }
+  );
+  updateActiveJob(filePath, { stage: "inicializando", progress: 0, detail: "Preparando recursos" });
+  void logActivity("info", `Processamento iniciado${action ? ` (${action})` : ""}`, {
+    filePath,
+    action: job?.action,
+  });
+
   const off = memoryGuard.onChange(() => {});
+  updateMemoryGuardListeners(memoryGuard.listenerCount());
+
+  let caughtError = null;
   try {
     await fn();
+    updateActiveJob(filePath, { progress: 1, stage: "finalizando", detail: "Finalizando" });
+  } catch (err) {
+    caughtError = err;
+    updateActiveJob(filePath, {
+      stage: "erro",
+      detail: err?.message ? err.message.slice(0, 200) : String(err),
+    });
+    throw err;
   } finally {
     try {
       await endLogger(filePath);
@@ -20,8 +50,15 @@ export async function withFileLifecycle(filePath, fn) {
       console.error(`[logger] Falha ao finalizar logger de ${filePath}:`, err?.message || err);
     } finally {
       off();
+      updateMemoryGuardListeners(memoryGuard.listenerCount());
       clearAllErrors(filePath);
       activeFiles.delete(filePath);
+      markJobComplete(job, { success: !caughtError, error: caughtError });
+      const level = caughtError ? "error" : "info";
+      const message = caughtError
+        ? `Processamento falhou: ${caughtError?.message || caughtError}`
+        : "Processamento concluído";
+      void logActivity(level, message, { filePath, action: job?.action });
     }
   }
 }


### PR DESCRIPTION
## Summary
- harden per-file logger lifecycle to avoid writes after closure and add activity logging
- track pipeline queue state and persist snapshots to logs/_queue.txt
- wire global activity log events, watchdog warnings, and process safety handlers

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c87b218cf88324a3989c5772cb5f8e