### PR TITLE
Avoid redundant CSV head reads in fast path

### DIFF
--- a/src/controller/createDataController.js
+++ b/src/controller/createDataController.js
@@ -5,11 +5,13 @@ import {
   readCsvHeader,
   normalizeHeadersOnce,
 } from "../utils/csvStream.js";
+import iconv from "iconv-lite";
 import { addAviso, addErro } from "../middleware/errorHandler.js";
 import {
   detectEncoding,
   detectDelimiter,
 } from "../utils/prepareStreamByFilepath.js";
+import { readHeadOnce } from "../utils/readHeadOnce.js";
 import {
   getColumnsFromTable,
   getTiposFromTable,
@@ -140,13 +142,35 @@ export async function createMetadadosController(filePath, action) {
   const caminho_truncado = truncarFilepath(filePath);
 
   if (PIPELINE_FAST_PATH) {
-    const { encoding } = await detectEncoding(filePath, {
-      headBytes: 64 * 1024,
-      fallback: "latin1",
-    });
+    const { headBuf } = await readHeadOnce(filePath, 64 * 1024);
+    const headSampleBytes = headBuf?.length ?? 0;
+    let { encoding } = await detectEncoding(
+      { filePath, headBuf, sampleBytes: headSampleBytes, fallback: "latin1" }
+    );
+
+    let encodingNorm = typeof encoding === "string" ? encoding.toLowerCase() : "utf8";
+    if (encodingNorm !== "latin1" && encodingNorm !== "utf8") {
+      encodingNorm = "utf8";
+    }
+    encoding = encodingNorm;
+
+    let headForText = headBuf ?? Buffer.alloc(0);
+    if (encodingNorm === "utf8" && headForText.length >= 3) {
+      if (headForText[0] === 0xef && headForText[1] === 0xbb && headForText[2] === 0xbf) {
+        headForText = headForText.subarray(3);
+      }
+    }
+
+    const headText =
+      encodingNorm === "latin1"
+        ? iconv.decode(headForText, "latin1")
+        : headForText.toString("utf8");
+
     const delimiter = await detectDelimiter(filePath, encoding, {
-      minHeadBytes: 64 * 1024,
-      maxHeadBytes: 64 * 1024,
+      minHeadBytes: headSampleBytes,
+      maxHeadBytes: headSampleBytes,
+      headText,
+      headBytes: headSampleBytes,
     });
     const rawHeaders = await readCsvHeader(filePath, encoding, delimiter, {
       highWaterMark: 64 * 1024,

--- a/src/utils/prepareStreamByFilepath.js
+++ b/src/utils/prepareStreamByFilepath.js
@@ -1,38 +1,48 @@
-import fs from "fs/promises";
 import { createReadStream } from "fs";
 import chardet from "chardet";
 import iconv from "iconv-lite";
 import { addInfo, addAviso } from "../middleware/errorHandler.js";
 import { performance } from "node:perf_hooks";
-
-async function readHead(filePath, bytes) {
-  const fh = await fs.open(filePath, "r");
-  try {
-    const buf = Buffer.allocUnsafe(bytes);
-    const { bytesRead } = await fh.read(buf, 0, bytes, 0);
-    return buf.subarray(0, bytesRead);
-  } finally {
-    await fh.close();
-  }
-}
+import { readHeadOnce } from "./readHeadOnce.js";
 
 /* ────────────────────────────────────────────────────────────────────────── */
 /* 1) DETECTAR ENCODING (lendo apenas um pedaço do início)                    */
 /* ────────────────────────────────────────────────────────────────────────── */
-export async function detectEncoding(
-  filePath,
-  { headBytes = 64 * 1024, fallback = "latin1" } = {}
-) {
+export async function detectEncoding(input, maybeOptions = {}) {
+  const opts = maybeOptions && typeof maybeOptions === "object" ? maybeOptions : {};
+  let filePath = typeof input === "string" ? input : undefined;
+  let headBuf = Buffer.isBuffer(input) ? input : undefined;
+
+  let sampleBytes = opts.headBytes ?? opts.sampleBytes ?? 64 * 1024;
+  let fallback = typeof opts.fallback === "string" ? opts.fallback : "latin1";
+
+  if (input && typeof input === "object" && !Buffer.isBuffer(input)) {
+    if (typeof input.filePath === "string") filePath = input.filePath;
+    if (Buffer.isBuffer(input.headBuf)) headBuf = input.headBuf;
+    if (typeof input.sampleBytes === "number") sampleBytes = input.sampleBytes;
+    if (typeof input.headBytes === "number") sampleBytes = input.headBytes;
+    if (typeof input.fallback === "string") fallback = input.fallback;
+  }
+
+  if (Buffer.isBuffer(opts.headBuf) && !headBuf) headBuf = opts.headBuf;
+  if (typeof opts.sampleBytes === "number") sampleBytes = opts.sampleBytes;
+  if (typeof opts.headBytes === "number") sampleBytes = opts.headBytes;
+  if (typeof opts.filePath === "string" && !filePath) filePath = opts.filePath;
+  if (typeof opts.fallback === "string") fallback = opts.fallback;
+
+  const logContext = filePath;
   const t0 = performance.now();
-  addInfo(`[Analyze] detectEncoding/start headBytes=${headBytes}`, filePath);
+  addInfo(`[Analyze] detectEncoding/start headBytes=${sampleBytes}`, logContext);
 
-  const head = await readHead(filePath, headBytes).catch(() => null);
-  addInfo(
-    `[Analyze] detectEncoding/head bytes=${head ? head.length : 0}`,
-    filePath
-  );
+  if (!headBuf && filePath) {
+    const res = await readHeadOnce(filePath, sampleBytes).catch(() => null);
+    headBuf = res?.headBuf ?? null;
+  }
 
-  const guess = head ? chardet.detect(head) : null;
+  const headBytes = headBuf ? headBuf.length : 0;
+  addInfo(`[Analyze] detectEncoding/head bytes=${headBytes}`, logContext);
+
+  const guess = headBuf ? chardet.detect(headBuf) : null;
   const s = (guess || "").toUpperCase();
 
   let encoding;
@@ -49,16 +59,16 @@ export async function detectEncoding(
   if (!guess) {
     addAviso(
       `[Analyze] detectEncoding/no-guess → fallback=${encoding} (${(t1 - t0).toFixed(0)}ms)`,
-      filePath
+      logContext
     );
   } else {
     addInfo(
       `[Analyze] detectEncoding/chardet="${s}" → ${encoding} (${(t1 - t0).toFixed(0)}ms)`,
-      filePath
+      logContext
     );
   }
 
-  return { encoding, head };
+  return { encoding, head: headBuf };
 }
 
 /* ────────────────────────────────────────────────────────────────────────── */
@@ -98,6 +108,8 @@ export async function detectDelimiter(
     minHeadBytes = 64 * 1024,
     maxHeadBytes = 1024 * 1024,
     head: preHead,
+    headText,
+    headBytes,
   } = {}
 ) {
   const t0 = performance.now();
@@ -106,23 +118,55 @@ export async function detectDelimiter(
     filePath
   );
 
-  let head = preHead ?? (await readHead(filePath, minHeadBytes));
+  let head = preHead;
+  const hasProvidedText = typeof headText === "string";
+  let reusedHead = Boolean(head) || hasProvidedText;
+  let bytesForLog = typeof headBytes === "number" ? headBytes : undefined;
+
+  if (!head && !hasProvidedText) {
+    const res = await readHeadOnce(filePath, minHeadBytes);
+    head = res.headBuf;
+  }
+
+  if (typeof bytesForLog !== "number" && head) {
+    bytesForLog = head.length;
+  }
+
+  if (reusedHead) {
+    addInfo(`[Analyze] detectDelimiter/reused_head=true`, filePath);
+  } else {
+    addInfo(`[Analyze] detectDelimiter/reused_head=false`, filePath);
+  }
+
+  if (typeof bytesForLog !== "number" && hasProvidedText) {
+    const byteEncoding = encoding === "latin1" ? "latin1" : "utf8";
+    bytesForLog = Buffer.byteLength(headText, byteEncoding);
+  }
+
   addInfo(
-    `[Analyze] detectDelimiter/head bytes=${head.length}`,
+    `[Analyze] detectDelimiter/head bytes=${bytesForLog ?? 0}`,
     filePath
   );
 
-  let text =
-    encoding === "latin1" ? iconv.decode(head, "latin1") : head.toString("utf8");
+  let text;
+  if (hasProvidedText) {
+    text = headText;
+  } else {
+    head = head ?? Buffer.alloc(0);
+    text =
+      encoding === "latin1" ? iconv.decode(head, "latin1") : head.toString("utf8");
+  }
 
   const hasNewline = text.includes("\n") || text.includes("\r");
-  if (!hasNewline && head.length < maxHeadBytes) {
-    const bigger = Math.min(head.length * 4, maxHeadBytes);
+  if (!hasNewline && (head?.length ?? bytesForLog ?? 0) < maxHeadBytes) {
+    const currentLen = head?.length ?? bytesForLog ?? 0;
+    const bigger = Math.min(currentLen * 4 || minHeadBytes, maxHeadBytes);
     addInfo(
       `[Analyze] detectDelimiter/no-newline → upscale head to ${bigger} bytes`,
       filePath
     );
-    head = await readHead(filePath, bigger);
+    const res = await readHeadOnce(filePath, bigger);
+    head = res.headBuf;
     text =
       encoding === "latin1"
         ? iconv.decode(head, "latin1")

--- a/src/utils/readHeadOnce.js
+++ b/src/utils/readHeadOnce.js
@@ -1,0 +1,12 @@
+import fs from "fs/promises";
+
+export async function readHeadOnce(filePath, sampleBytes = 64 * 1024) {
+  const fileHandle = await fs.open(filePath, "r");
+  try {
+    const buf = Buffer.allocUnsafe(sampleBytes);
+    const { bytesRead } = await fileHandle.read(buf, 0, sampleBytes, 0);
+    return { headBuf: buf.subarray(0, bytesRead) };
+  } finally {
+    await fileHandle.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `readHeadOnce` helper so the pipeline can cache the CSV head chunk
- extend the encoding and delimiter detectors to accept preloaded buffers/text and emit reuse-aware logs
- update the fast-path metadata builder to decode the cached head once, strip BOMs, and share it across both detection steps

## Testing
- node -e "import('./src/controller/createDataController.js').then(()=>{console.log('loaded');process.exit(0);}).catch((err)=>{console.error(err);process.exit(1);});"
- node -e "import('./src/utils/prepareStreamByFilepath.js').then(()=>{console.log('stream utils loaded');process.exit(0);}).catch((err)=>{console.error(err);process.exit(1);});"
- node <<'EOF'
import { performance } from 'node:perf_hooks';
import { detectEncoding, detectDelimiter } from './src/utils/prepareStreamByFilepath.js';
import { readHeadOnce } from './src/utils/readHeadOnce.js';
import iconv from 'iconv-lite';

const filePath = '/tmp/big.csv';
const iterations = 5;

async function oldFlow() {
  let total = 0;
  for (let i = 0; i < iterations; i++) {
    const t0 = performance.now();
    const { encoding } = await detectEncoding(filePath, { headBytes: 64 * 1024, fallback: 'latin1' });
    await detectDelimiter(filePath, encoding, {
      minHeadBytes: 64 * 1024,
      maxHeadBytes: 64 * 1024,
    });
    total += performance.now() - t0;
  }
  return total / iterations;
}

async function newFlow() {
  let total = 0;
  for (let i = 0; i < iterations; i++) {
    const t0 = performance.now();
    const { headBuf } = await readHeadOnce(filePath, 64 * 1024);
    const headLen = headBuf?.length ?? 0;
    let { encoding } = await detectEncoding({ filePath, headBuf, sampleBytes: headLen, fallback: 'latin1' });
    encoding = typeof encoding === 'string' ? encoding.toLowerCase() : 'utf8';
    if (encoding !== 'latin1' && encoding !== 'utf8') encoding = 'utf8';
    let headForText = headBuf ?? Buffer.alloc(0);
    if (encoding === 'utf8' && headForText.length >= 3) {
      if (headForText[0] === 0xef && headForText[1] === 0xbb && headForText[2] === 0xbf) {
        headForText = headForText.subarray(3);
      }
    }
    const headText = encoding === 'latin1' ? iconv.decode(headForText, 'latin1') : headForText.toString('utf8');
    await detectDelimiter(filePath, encoding, {
      minHeadBytes: headLen,
      maxHeadBytes: headLen,
      headText,
      headBytes: headLen,
    });
    total += performance.now() - t0;
  }
  return total / iterations;
}

const oldAvg = await oldFlow();
const newAvg = await newFlow();
console.log(JSON.stringify({ iterations, oldAvgMs: oldAvg, newAvgMs: newAvg }, null, 2));
EOF

## Benchmark
| Flow | Avg ms (5 runs) |
| --- | --- |
| old (double head read) | 41.30 |
| new (single head read reused) | 31.20 |


------
https://chatgpt.com/codex/tasks/task_e_68c9b2cd96148324864f6598c82d4bb1