### PR TITLE
Centralize overlap decision and reuse metadata

### DIFF
--- a/src/controller/createDataController.js
+++ b/src/controller/createDataController.js
@@ -6,7 +6,7 @@ import {
   normalizeHeadersOnce,
 } from "../utils/csvStream.js";
 import iconv from "iconv-lite";
-import { addAviso, addErro } from "../middleware/errorHandler.js";
+import { addAviso, addErro, addInfo } from "../middleware/errorHandler.js";
 import {
   detectEncoding,
   detectDelimiter,
@@ -16,8 +16,11 @@ import {
   getColumnsFromTable,
   getTiposFromTable,
   getDateColumnsFromTable,
+  buildRangeFromMetadados,
 } from "../model/tableModel.js";
 import { PIPELINE_FAST_PATH } from "../../config/index.js";
+import { decideOverlapPolicy } from "../utils/decideOverlapPolicy.js";
+import { logActivity } from "../middleware/logger.js";
 
 /* ---------- hot helpers ---------- */
 function isAllDigits(s) {
@@ -183,7 +186,7 @@ export async function createMetadadosController(filePath, action) {
       getDateColumnsFromTable(destino.tabela_destino),
     ]);
 
-    return {
+    const metadados = {
       nome_arquivo: destino.nome_arquivo,
       ano: destino.ano,
       mes: destino.mes,
@@ -204,11 +207,14 @@ export async function createMetadadosController(filePath, action) {
       caminho_original: filePath,
       caminho_truncado,
     };
+
+    await ensureOverlapMetadata(metadados, filePath, action);
+    return metadados;
   }
 
   const analise = await analyzeCsv(filePath, destino.tabela_destino);
 
-  return {
+  const metadados = {
     nome_arquivo: destino.nome_arquivo,
     ano: destino.ano,
     mes: destino.mes,
@@ -228,6 +234,48 @@ export async function createMetadadosController(filePath, action) {
 
     caminho_original: filePath,
     caminho_truncado,
+  };
+
+  await ensureOverlapMetadata(metadados, filePath, action);
+  return metadados;
+}
+
+async function ensureOverlapMetadata(metadados, contexto, action) {
+  if (!metadados) return null;
+  if (metadados.overlap) {
+    if (!metadados.range) {
+      metadados.range = buildRangeFromMetadados(metadados);
+    }
+    return metadados.overlap;
+  }
+
+  const range = metadados.range ?? buildRangeFromMetadados(metadados);
+  metadados.range = range || null;
+
+  const logger = createOverlapLogger(contexto, action);
+  const decision = await decideOverlapPolicy({
+    table: metadados.tabela,
+    dateCol: metadados.coluna_data,
+    range,
+    logger,
+  });
+  metadados.overlap = decision;
+  return decision;
+}
+
+function createOverlapLogger(contexto, action) {
+  return {
+    info(message, payload = {}) {
+      try {
+        const serialized = JSON.stringify(payload);
+        const line = `${message} ${serialized}`;
+        addInfo(line, contexto);
+        void logActivity("info", line, { filePath: contexto, action });
+      } catch (err) {
+        addInfo(`${message} ${payload ? String(payload) : ""}`, contexto);
+        void logActivity("info", message, { filePath: contexto, action });
+      }
+    },
   };
 }
 

--- a/src/controller/fluxoValidatorController.js
+++ b/src/controller/fluxoValidatorController.js
@@ -1,6 +1,8 @@
-import { addErro, addInfo } from "../middleware/errorHandler.js";
+import { addErro, addInfo, addAviso } from "../middleware/errorHandler.js";
 import { getLogByData, getAllHashesFromTable, findLogByFileMeta } from "../model/logModel.js";
-import { existsAnyDataInRange } from "../model/tableModel.js";
+import { decideOverlapPolicy } from "../utils/decideOverlapPolicy.js";
+import { buildRangeFromMetadados } from "../model/tableModel.js";
+import { logActivity } from "../middleware/logger.js";
 import { PIPELINE_FAST_PATH } from "../../config/index.js";
 
 export default async function fluxoValidatorController(metadados, logData) {
@@ -10,6 +12,18 @@ export default async function fluxoValidatorController(metadados, logData) {
 
   const fastPath = PIPELINE_FAST_PATH === "true";
 
+  const overlap = await ensureOverlapDecision(metadados, contexto);
+  const strategy = overlap?.strategy || "insert";
+  const hasOverlap = overlap?.hasOverlap === true;
+  metadados.applyPreDelete = strategy === "replace";
+
+  logOverlapUsage(contexto, {
+    strategy,
+    hasOverlap,
+    reason: overlap?.reason ?? null,
+    range: metadados.range ?? null,
+  });
+
   if (fastPath) {
     if (!logData?.hash_arquivo) {
       addInfo(
@@ -17,20 +31,15 @@ export default async function fluxoValidatorController(metadados, logData) {
         contexto
       );
     }
-    try {
-      const overlap = await existsAnyDataInRange(metadados);
-      if (overlap) {
-        addInfo(
-          `[ARQUIVO MODIFICADO] [${nome}] já existia, mas foi alterado. Reprocessando.`,
-          contexto
-        );
-        console.log(
-          `[🟡 MODIFICADO] [${nome}] sera inserido na tabela [${tabela}]`
-        );
-        return "reprocessar";
-      }
-    } catch (e) {
-      addErro(`Erro ao verificar dados existentes: ${e.message}`, contexto);
+    if (hasOverlap) {
+      addInfo(
+        `[ARQUIVO MODIFICADO] [${nome}] já existia, mas foi alterado. Reprocessando.`,
+        contexto
+      );
+      console.log(
+        `[🟡 MODIFICADO] [${nome}] sera inserido na tabela [${tabela}]`
+      );
+      return "reprocessar";
     }
 
     addInfo(`[NOVO ARQUIVO] [${nome}] será processado.`, contexto);
@@ -109,4 +118,56 @@ export default async function fluxoValidatorController(metadados, logData) {
     `[🟡 MODIFICADO] [${nome}] sera inserido na tabela [${tabela}], validar lógica de atualização para o tipo do arquivo`
   );
   return "reprocessar";
+}
+
+async function ensureOverlapDecision(metadados, contexto) {
+  if (!metadados) return null;
+  if (metadados.overlap) {
+    if (!metadados.range) {
+      metadados.range = buildRangeFromMetadados(metadados);
+    }
+    return metadados.overlap;
+  }
+
+  addAviso(
+    "[OverlapDecision] Metadados sem decisão prévia; calculando tardiamente.",
+    contexto
+  );
+  const range = metadados.range ?? buildRangeFromMetadados(metadados);
+  metadados.range = range || null;
+  const decision = await decideOverlapPolicy({
+    table: metadados.tabela,
+    dateCol: metadados.coluna_data,
+    range,
+    logger: createOverlapLogger(contexto),
+  });
+  metadados.overlap = decision;
+  return decision;
+}
+
+function createOverlapLogger(contexto) {
+  return {
+    info(message, payload = {}) {
+      try {
+        const serialized = JSON.stringify(payload);
+        const line = `${message} ${serialized}`;
+        addInfo(line, contexto);
+        void logActivity("info", line, { filePath: contexto });
+      } catch (err) {
+        addInfo(`${message} ${payload ? String(payload) : ""}`, contexto);
+        void logActivity("info", message, { filePath: contexto });
+      }
+    },
+  };
+}
+
+function logOverlapUsage(contexto, payload) {
+  try {
+    const line = `[OverlapDecision][Use] ${JSON.stringify(payload)}`;
+    addInfo(line, contexto);
+    void logActivity("info", line, { filePath: contexto });
+  } catch (err) {
+    addInfo("[OverlapDecision][Use]", contexto);
+    void logActivity("info", "[OverlapDecision][Use]", { filePath: contexto });
+  }
 }

--- a/src/controller/managerDataController.js
+++ b/src/controller/managerDataController.js
@@ -1,4 +1,4 @@
-import { deleteFromTable, existsAnyDataInRange, existsAnyCsvDateInTable } from "../model/tableModel.js";
+import { deleteFromTable, buildRangeFromMetadados } from "../model/tableModel.js";
 import {
   iniciarBarra,
   atualizarBarra,
@@ -7,6 +7,7 @@ import {
 
 import { addAviso, addErro, addInfo } from "../middleware/errorHandler.js";
 import { logActivity } from "../middleware/logger.js";
+import { decideOverlapPolicy } from "../utils/decideOverlapPolicy.js";
 import streamPipeline, {
   POOL_MAX,
   INSERT_MAX_CONCURRENT,
@@ -166,21 +167,22 @@ export async function manageInsertController(metadados, logData) {
       });
     }
 
-    let validator;
-    try {
-      const overlap = PIPELINE_FAST_PATH
-        ? await existsAnyDataInRange(metadados)
-        : await existsAnyCsvDateInTable(metadados); // true/false/null
-      if (overlap === null) {
-        // Sem coluna_data → segue sua regra original
-        validator = "cadastro";
-      } else {
-        validator = overlap ? "substituir" : "inserir";
-      }
-    } catch (e) {
-      addErro(`Erro ao validar datas no banco: ${e.message}`, contexto);
-      throw e;
-    }
+    const overlapDecision = await ensureOverlapDecision(metadados, contexto);
+    const strategy = overlapDecision?.strategy || "insert";
+    const hasOverlap = overlapDecision?.hasOverlap === true;
+    metadados.applyPreDelete = strategy === "replace";
+
+    logManageStrategy(contexto, {
+      usingStrategy: strategy,
+      hasOverlap,
+      reason: overlapDecision?.reason ?? null,
+      range: metadados.range ?? null,
+      applyPreDelete: metadados.applyPreDelete,
+    });
+
+    const validator = strategy === "replace"
+      ? metadados.coluna_data ? "substituir" : "cadastro"
+      : "inserir";
 
     if (validator === "cadastro" || validator === "substituir") {
       try {
@@ -196,16 +198,6 @@ export async function manageInsertController(metadados, logData) {
         void logActivity("error", `Falha ao deletar período: ${e.message}`, { filePath: contexto });
         throw e;
       }
-    } else if (validator === null) {
-      addErro("Validação nula (dados inválidos ou sem coluna de data).", contexto);
-      void logActivity("warn", "Validação nula: dados inválidos", { filePath: contexto });
-      return {
-        erro: true,
-        total: totalForReturn,
-        inseridos: 0,
-        falhas: totalForReturn,
-        mensagem: "Validação nula",
-      };
     }
 
     addInfo("Iniciando leitura e montagem de lotes...", contexto);
@@ -271,6 +263,59 @@ export async function manageInsertController(metadados, logData) {
     }
   } finally {
     await finalizarBarra(barraId);
+  }
+}
+
+
+async function ensureOverlapDecision(metadados, contexto) {
+  if (!metadados) return null;
+  if (metadados.overlap) {
+    if (!metadados.range) {
+      metadados.range = buildRangeFromMetadados(metadados);
+    }
+    return metadados.overlap;
+  }
+
+  addAviso(
+    "[OverlapDecision] Metadados sem decisão prévia; calculando tardiamente (manager).",
+    contexto
+  );
+  const range = metadados.range ?? buildRangeFromMetadados(metadados);
+  metadados.range = range || null;
+  const decision = await decideOverlapPolicy({
+    table: metadados.tabela,
+    dateCol: metadados.coluna_data,
+    range,
+    logger: createOverlapLogger(contexto, metadados.acao),
+  });
+  metadados.overlap = decision;
+  return decision;
+}
+
+function createOverlapLogger(contexto, action) {
+  return {
+    info(message, payload = {}) {
+      try {
+        const serialized = JSON.stringify(payload);
+        const line = `${message} ${serialized}`;
+        addInfo(line, contexto);
+        void logActivity("info", line, { filePath: contexto, action });
+      } catch (err) {
+        addInfo(`${message} ${payload ? String(payload) : ""}`, contexto);
+        void logActivity("info", message, { filePath: contexto, action });
+      }
+    },
+  };
+}
+
+function logManageStrategy(contexto, payload) {
+  try {
+    const line = `[ManageInsert] ${JSON.stringify(payload)}`;
+    addInfo(line, contexto);
+    void logActivity("info", line, { filePath: contexto });
+  } catch (err) {
+    addInfo("[ManageInsert]", contexto);
+    void logActivity("info", "[ManageInsert]", { filePath: contexto });
   }
 }
 

--- a/src/model/overlapQueries.js
+++ b/src/model/overlapQueries.js
@@ -1,0 +1,85 @@
+import { query } from "../../config/dbPool.js";
+import { schema } from "../../config/index.js";
+
+function toDate(value) {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null;
+    return new Date(value.getTime());
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) return null;
+    return parsed;
+  }
+  return null;
+}
+
+function toIsoDay(date) {
+  if (!date) return null;
+  return date.toISOString().slice(0, 10);
+}
+
+function normalizeRange(range) {
+  if (!range) return null;
+  const startInput = range.start ?? range.begin ?? range.inicio;
+  const startDate = toDate(startInput);
+  if (!startDate) return null;
+
+  let endExclusiveDate = null;
+  if (range.endExclusive != null) {
+    endExclusiveDate = toDate(range.endExclusive);
+  }
+  if (!endExclusiveDate) {
+    const endInput = range.end ?? range.finish ?? range.stop ?? range.final;
+    const endDate = toDate(endInput);
+    if (!endDate) return null;
+    endExclusiveDate = new Date(endDate.getTime());
+    endExclusiveDate.setUTCDate(endExclusiveDate.getUTCDate() + 1);
+  }
+
+  const startIso = toIsoDay(startDate);
+  const endExclusiveIso = toIsoDay(endExclusiveDate);
+  if (!startIso || !endExclusiveIso) return null;
+  if (endExclusiveIso <= startIso) return null;
+
+  return { start: startIso, endExclusive: endExclusiveIso };
+}
+
+async function runQuery(executor, sql, params) {
+  const result = await executor(sql, params);
+  if (Array.isArray(result)) {
+    if (Array.isArray(result[0])) return result[0];
+    return result;
+  }
+  return result;
+}
+
+export async function existsAnyDataInRange({ table, dateCol, range, db }) {
+  if (!table || !dateCol) return null;
+  const normalizedRange = normalizeRange(range);
+  if (!normalizedRange) return null;
+
+  let executor = query;
+  if (db && typeof db.query === "function") {
+    executor = db.query.bind(db);
+  }
+
+  const sql = `
+      SELECT 1
+      FROM \`${schema}\`.\`${table}\`
+      WHERE \`${dateCol}\` >= ? AND \`${dateCol}\` < ?
+      LIMIT 1
+    `;
+  try {
+    const rows = await runQuery(executor, sql, [normalizedRange.start, normalizedRange.endExclusive]);
+    return Array.isArray(rows) && rows.length > 0;
+  } catch (e) {
+    throw new Error(`[overlap exists range] Erro ao consultar range de datas: ${e.message}`);
+  }
+}
+
+export function normalizeRangeInput(range) {
+  return normalizeRange(range);
+}

--- a/src/model/tableModel.js
+++ b/src/model/tableModel.js
@@ -2,6 +2,7 @@ import { query } from "../../config/dbPool.js";
 import { schema } from "../../config/index.js";
 import mapearTipo from "../utils/mapearTipos.js";
 import { addAviso } from "../middleware/errorHandler.js";
+import { existsAnyDataInRange as existsAnyDataInRangeQuery } from "./overlapQueries.js";
 
 /* -------------------- Caches de metadados -------------------- */
 const schemaCache = new Map();
@@ -49,7 +50,7 @@ function monthToNumber(m) {
 }
 
 /** Retorna [inicio, fimExclusivo] (YYYY-MM-DD) para filtros sargáveis por data. */
-function computeDateRange({ ano, mes, dia }) {
+export function computeDateRange({ ano, mes, dia }) {
   const y = Number(ano);
   if (!y || !mes) return null;
 
@@ -74,24 +75,42 @@ function computeDateRange({ ano, mes, dia }) {
   return [i, f];
 }
 
-export async function existsAnyDataInRange(metadados) {
-  const { tabela, coluna_data, ano, mes, dia } = metadados;
-  if (!tabela || !coluna_data) return null;
-  const range = computeDateRange({ ano, mes, dia });
-  if (!range) return null;
-  const [inicio, fim] = range;
-  const sql = `
-      SELECT 1
-      FROM \`${schema}\`.\`${tabela}\`
-      WHERE \`${coluna_data}\` >= ? AND \`${coluna_data}\` < ?
-      LIMIT 1
-    `;
-  try {
-    const rows = await query(sql, [inicio, fim]);
-    return rows.length > 0;
-  } catch (e) {
-    throw new Error(`[model exists range] Erro ao consultar range de datas: ${e.message}`);
+function inclusiveEndFromExclusive(endExclusive) {
+  if (!endExclusive) return null;
+  const date = new Date(`${endExclusive}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().slice(0, 10);
+}
+
+export function buildRangeFromMetadados(meta) {
+  if (!meta) return null;
+  const rangeTuple = computeDateRange(meta);
+  if (!rangeTuple) return null;
+  const [startIso, endExclusiveIso] = rangeTuple;
+  const inclusiveEnd = inclusiveEndFromExclusive(endExclusiveIso);
+  return {
+    start: startIso,
+    end: inclusiveEnd,
+    endExclusive: endExclusiveIso,
+  };
+}
+
+export async function existsAnyDataInRange(input) {
+  if (!input) return null;
+  if (input.table || input.dateCol || input.range || input.db) {
+    return existsAnyDataInRangeQuery(input);
   }
+  const { tabela, coluna_data } = input;
+  if (!tabela || !coluna_data) return null;
+  const rangeObj = buildRangeFromMetadados(input);
+  if (!rangeObj) return null;
+  return existsAnyDataInRangeQuery({
+    table: tabela,
+    dateCol: coluna_data,
+    range: rangeObj,
+    db: input.db,
+  });
 }
 
 /** Gera "(?, ?, ...)" repetido N vezes e o array achatado de valores. */
@@ -222,17 +241,15 @@ export async function existsAnyCsvDateInTable(metadados, opts = {}) {
   // max exclusive (+1 dia)
   const maxPlus1 = new Date(max);
   maxPlus1.setUTCDate(maxPlus1.getUTCDate() + 1);
-  const maxEx = maxPlus1.toISOString().slice(0,10);
+  const maxEx = maxPlus1.toISOString().slice(0, 10);
 
   {
-    const sqlRange = `
-      SELECT 1
-      FROM \`${schema}\`.\`${tabela}\`
-      WHERE \`${coluna_data}\` >= ? AND \`${coluna_data}\` < ?
-      LIMIT 1
-    `;
-    const r = await query(sqlRange, [min, maxEx]);
-    if (r.length === 0) return false; // nada no intervalo => certeza de não haver interseção
+    const overlap = await existsAnyDataInRangeQuery({
+      table: tabela,
+      dateCol: coluna_data,
+      range: { start: min, endExclusive: maxEx },
+    });
+    if (!overlap) return false; // nada no intervalo => certeza de não haver interseção
   }
 
   // 2) confirmação exata via IN chunked (mantém corretude)

--- a/src/utils/decideOverlapPolicy.js
+++ b/src/utils/decideOverlapPolicy.js
@@ -1,0 +1,84 @@
+import { existsAnyDataInRange, normalizeRangeInput } from "../model/overlapQueries.js";
+
+function emit(logger, payload) {
+  try {
+    logger?.info?.("[OverlapDecision]", payload);
+  } catch (err) {
+    // logger falhou — segue sem interromper o fluxo
+  }
+}
+
+export async function decideOverlapPolicy({ table, dateCol, range, db, logger } = {}) {
+  const checkedAt = new Date().toISOString();
+  const basePayload = {
+    table: table ?? null,
+    dateCol: dateCol ?? null,
+    checkedAt,
+  };
+
+  if (!table) {
+    const decision = {
+      hasOverlap: false,
+      strategy: "replace",
+      reason: "table-missing",
+      checkedAt,
+    };
+    emit(logger, { ...basePayload, range: range ?? null, ...decision });
+    return decision;
+  }
+
+  if (!dateCol) {
+    const decision = {
+      hasOverlap: false,
+      strategy: "replace",
+      reason: "date-column-missing",
+      checkedAt,
+    };
+    emit(logger, { ...basePayload, range: range ?? null, ...decision });
+    return decision;
+  }
+
+  const normalizedRange = normalizeRangeInput(range);
+  if (!normalizedRange) {
+    const decision = {
+      hasOverlap: false,
+      strategy: "replace",
+      reason: "range-missing",
+      checkedAt,
+    };
+    emit(logger, { ...basePayload, range: range ?? null, ...decision });
+    return decision;
+  }
+
+  try {
+    const hasOverlap = await existsAnyDataInRange({
+      table,
+      dateCol,
+      range: normalizedRange,
+      db,
+    });
+    const strategy = hasOverlap ? "replace" : "insert";
+    const decision = {
+      hasOverlap: Boolean(hasOverlap),
+      strategy,
+      reason: hasOverlap ? "overlap-found" : "no-overlap",
+      checkedAt,
+    };
+    emit(logger, { ...basePayload, range: normalizedRange, ...decision });
+    return decision;
+  } catch (err) {
+    const decision = {
+      hasOverlap: false,
+      strategy: "replace",
+      reason: "query-error",
+      checkedAt,
+    };
+    emit(logger, {
+      ...basePayload,
+      range: normalizedRange,
+      error: err?.message,
+      ...decision,
+    });
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared overlap query helper and decision utility for ingestion strategies
- capture the overlap policy during metadata creation and log the first decision
- reuse the cached overlap strategy in validator and manager controllers to avoid redundant queries and duplicate logging

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c9be6fee008324abfd492742d1c439