### PR TITLE
Implement local staging pipeline for CSV ingestion

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -19,3 +19,10 @@ export const RAM_GUARD_INTERVAL_MS = Number(process.env.RAM_GUARD_INTERVAL_MS);
 // aliases for backwards compatibility
 export const QUEUE_HIGH_WATERMARK = HIGH_WATERMARK_DEFAULT;
 export const QUEUE_LOW_WATERMARK = LOW_WATERMARK_DEFAULT;
+
+// staging configuration (used by pipeline)
+export const STAGING_DIR = process.env.STAGING_DIR;
+export const STAGING_REUSE = process.env.STAGING_REUSE;
+export const STAGING_VERIFY = process.env.STAGING_VERIFY;
+export const STAGING_CLEANUP_ON_SUCCESS = process.env.STAGING_CLEANUP_ON_SUCCESS;
+export const STAGING_CLEANUP_TTL_MIN = process.env.STAGING_CLEANUP_TTL_MIN;

--- a/src/controller/Handlers/createdHandler.js
+++ b/src/controller/Handlers/createdHandler.js
@@ -1,11 +1,53 @@
-import { addErro, addInfo } from "../../middleware/errorHandler.js";
+import { addAviso, addErro, addInfo } from "../../middleware/errorHandler.js";
 import { insertLog } from "../../model/logModel.js";
 import createDataController from "../createDataController.js";
 import fluxoValidatorController from "../fluxoValidatorController.js";
 import { manageInsertController } from "../managerDataController.js";
-import { PIPELINE_FAST_PATH } from "../../../config/index.js";
+import {
+  PIPELINE_FAST_PATH,
+  STAGING_CLEANUP_ON_SUCCESS,
+  STAGING_CLEANUP_TTL_MIN,
+  STAGING_DIR,
+  STAGING_REUSE,
+  STAGING_VERIFY,
+} from "../../../config/index.js";
 import { withFileLifecycle } from "../../utils/withFileLifecycle.js";
 import { markJobComplete } from "../../utils/queueTracker.js";
+import { ensureLocalStaging } from "../../utils/ensureLocalStaging.js";
+import { cleanupStaging } from "../../utils/cleanupStaging.js";
+import { unlink } from "fs/promises";
+
+function parseBoolean(value, defaultValue) {
+  if (value == null) return defaultValue;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return defaultValue;
+    if (["1", "true", "yes", "sim", "y"].includes(normalized)) return true;
+    if (["0", "false", "no", "nao", "não", "n"].includes(normalized)) return false;
+  }
+  return defaultValue;
+}
+
+function parseNumber(value, defaultValue) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : defaultValue;
+}
+
+function createStagingLogger(filePath) {
+  return {
+    info(message) {
+      addInfo(`[Staging] ${message}`, filePath);
+    },
+    warn(message) {
+      addAviso(`[Staging] ${message}`, filePath);
+    },
+    error(message) {
+      addErro(`[Staging] ${message}`, filePath);
+    },
+  };
+}
 
 export default async function createdHandler(filePath, action, job) {
   const useFastPath = PIPELINE_FAST_PATH; // kept for compatibility
@@ -23,51 +65,126 @@ export default async function createdHandler(filePath, action, job) {
   await withFileLifecycle(
     filePath,
     async () => {
-      let metadados, logData;
+      const stagingLogger = createStagingLogger(filePath);
+      const reuse = parseBoolean(STAGING_REUSE, true);
+      const verify = parseBoolean(STAGING_VERIFY, true);
+      const cleanupOnSuccess = parseBoolean(STAGING_CLEANUP_ON_SUCCESS, true);
+      const cleanupTtlMin = parseNumber(STAGING_CLEANUP_TTL_MIN, 120);
+      const stagingDirEnv =
+        typeof STAGING_DIR === "string" && STAGING_DIR.trim().length > 0
+          ? STAGING_DIR.trim()
+          : undefined;
+
+      let stagingInfo = null;
+      let metadados;
+      let logData;
+      let processingSucceeded = false;
+
       try {
-        const result = await createDataController(filePath, action);
-        ({ metadados, logData } = result || {});
-      } catch (e) {
-      addErro(`erro ao gerar os dados fundamentais, erro:${e.message}`, filePath);
-      return;
-    }
+        try {
+          stagingInfo = await ensureLocalStaging({
+            srcPath: filePath,
+            stagingDir: stagingDirEnv,
+            reuse,
+            verify,
+            logger: stagingLogger,
+          });
+        } catch (err) {
+          addErro(
+            `[Staging] falha ao preparar cópia local: ${err?.message || err}`,
+            filePath
+          );
+          return;
+        }
 
-    if (!metadados || !logData) {
-      addErro("metadados ou logData não foram gerados corretamente", filePath);
-      return;
-    }
+        const workFilePath = stagingInfo?.effectivePath || filePath;
 
-    let fluxo;
-    try {
-      fluxo = await fluxoValidatorController(metadados, logData);
-    } catch (e) {
-      addErro(`Erro ao validar fluxo de ingestão: ${e.message}`, filePath);
-      return;
-    }
+        try {
+          const result = await createDataController(filePath, action, {
+            workFilePath,
+            stagingInfo,
+          });
+          ({ metadados, logData } = result || {});
+        } catch (e) {
+          addErro(`erro ao gerar os dados fundamentais, erro:${e.message}`, filePath);
+          return;
+        }
 
-    if (fluxo !== "inserir" && fluxo !== "reprocessar") {
-      addInfo(
-        `[ARQUIVO IGNORADO] ${metadados.nome_arquivo} já existe e não foi modificado.`,
-        filePath
-      );
-      await insertLog(logData);
-      return;
-    }
+        if (!metadados || !logData) {
+          addErro("metadados ou logData não foram gerados corretamente", filePath);
+          return;
+        }
 
-    try {
-      const resultado = await manageInsertController(metadados, logData);
-      logData.sucesso = !resultado?.erro;
-      logData.mensagem_erro = resultado?.mensagem || null;
-      logData.hash_arquivo = metadados.hash;
-      logData.total_linhas = metadados.total_linhas;
-      if (resultado?.erro) addErro(logData.mensagem_erro, filePath);
-    } catch (e) {
-      logData.sucesso = false;
-      logData.mensagem_erro = `Erro durante execução do managerDataController: ${e.message}`;
-      addErro(logData.mensagem_erro, filePath);
-    } finally {
-      await insertLog(logData);
-    }
+        let fluxo;
+        try {
+          fluxo = await fluxoValidatorController(metadados, logData);
+        } catch (e) {
+          addErro(`Erro ao validar fluxo de ingestão: ${e.message}`, filePath);
+          return;
+        }
+
+        if (fluxo !== "inserir" && fluxo !== "reprocessar") {
+          addInfo(
+            `[ARQUIVO IGNORADO] ${metadados.nome_arquivo} já existe e não foi modificado.`,
+            filePath
+          );
+          await insertLog(logData);
+          processingSucceeded = true;
+          return;
+        }
+
+        try {
+          const resultado = await manageInsertController(metadados, logData);
+          logData.sucesso = !resultado?.erro;
+          logData.mensagem_erro = resultado?.mensagem || null;
+          logData.hash_arquivo = metadados.hash;
+          logData.total_linhas = metadados.total_linhas;
+          if (resultado?.erro) addErro(logData.mensagem_erro, filePath);
+        } catch (e) {
+          logData.sucesso = false;
+          logData.mensagem_erro = `Erro durante execução do managerDataController: ${e.message}`;
+          addErro(logData.mensagem_erro, filePath);
+        } finally {
+          await insertLog(logData);
+        }
+
+        processingSucceeded = Boolean(logData?.sucesso);
+      } finally {
+        if (stagingInfo && stagingInfo.isRemote && stagingInfo.effectivePath) {
+          const isDifferentPath = stagingInfo.effectivePath !== filePath;
+          const hasCopy = stagingInfo.copied || stagingInfo.reused;
+          if (isDifferentPath && hasCopy) {
+            if (processingSucceeded && cleanupOnSuccess) {
+              try {
+                await unlink(stagingInfo.effectivePath);
+                stagingLogger.info(
+                  `cópia local removida após sucesso (${stagingInfo.effectivePath})`
+                );
+              } catch (err) {
+                stagingLogger.warn(
+                  `falha ao remover cópia local (${stagingInfo.effectivePath}): ${err?.message || err}`
+                );
+              }
+            } else if (!processingSucceeded) {
+              stagingLogger.info(
+                `mantendo cópia local para análise (${stagingInfo.effectivePath})`
+              );
+            }
+          }
+        }
+
+        if (stagingInfo?.stagingDir) {
+          try {
+            await cleanupStaging({
+              stagingDir: stagingInfo.stagingDir,
+              ttlMinutes: cleanupTtlMin,
+              logger: stagingLogger,
+            });
+          } catch (err) {
+            stagingLogger.warn(`cleanup tardio falhou: ${err?.message || err}`);
+          }
+        }
+      }
     },
     { job, action }
   );

--- a/src/controller/createDataController.js
+++ b/src/controller/createDataController.js
@@ -21,6 +21,7 @@ import {
 import { PIPELINE_FAST_PATH } from "../../config/index.js";
 import { decideOverlapPolicy } from "../utils/decideOverlapPolicy.js";
 import { logActivity } from "../middleware/logger.js";
+import { isRemotePath } from "../utils/ensureLocalStaging.js";
 
 /* ---------- hot helpers ---------- */
 function isAllDigits(s) {
@@ -94,8 +95,13 @@ export function truncarFilepath(fullpath) {
 
 /* ---------- controllers ---------- */
 
-export default async function createDataController(filePath, action) {
-  return createFundamentalDocsController(filePath, action, filePath)
+export default async function createDataController(filePath, action, opts = {}) {
+  const workFilePath =
+    opts && typeof opts.workFilePath === "string" ? opts.workFilePath : filePath;
+  return createFundamentalDocsController(filePath, action, filePath, {
+    workFilePath,
+    stagingInfo: opts?.stagingInfo ?? null,
+  })
     .then((result) => {
       const m = result?.metadados;
       if (!m) {
@@ -119,16 +125,36 @@ export default async function createDataController(filePath, action) {
 export async function createFundamentalDocsController(
   filePath,
   action,
-  contexto
+  contexto,
+  opts = {}
 ) {
   try {
-    const metadados = await createMetadadosController(filePath, action);
-    const { size } = await stat(filePath);
+    const workFilePath =
+      opts && typeof opts.workFilePath === "string" ? opts.workFilePath : filePath;
+    const metadados = await createMetadadosController(filePath, action, opts);
+    const { size } = await stat(workFilePath);
     metadados.file_size_bytes = size;
     // total_linhas já preenchido em createMetadadosController
     const logData = createLogDataController(metadados, null);
     logData.file_size_bytes = metadados.file_size_bytes;
     logData.total_linhas = metadados.total_linhas;
+
+    const stagingInfo = opts?.stagingInfo ?? null;
+    const isRemoteSource = stagingInfo?.isRemote ?? isRemotePath(filePath);
+    const copiedNow = Boolean(stagingInfo?.copied);
+    const reusedCopy = Boolean(stagingInfo?.reused);
+    const existingPaths =
+      metadados.paths && typeof metadados.paths === "object" ? metadados.paths : {};
+    metadados.paths = {
+      ...existingPaths,
+      source: existingPaths.source || filePath,
+      work: workFilePath,
+      isRemoteSource,
+      copiedToLocal: Boolean(copiedNow || reusedCopy),
+      copiedNow,
+      reusedLocalCopy: reusedCopy,
+      stagingDir: stagingInfo?.stagingDir ?? existingPaths.stagingDir ?? null,
+    };
     return { metadados, logData };
   } catch (e) {
     addErro(
@@ -140,15 +166,17 @@ export async function createFundamentalDocsController(
   }
 }
 
-export async function createMetadadosController(filePath, action) {
+export async function createMetadadosController(filePath, action, opts = {}) {
   const destino = destinoByFilePath(filePath);
   const caminho_truncado = truncarFilepath(filePath);
+  const workFilePath =
+    opts && typeof opts.workFilePath === "string" ? opts.workFilePath : filePath;
 
   if (PIPELINE_FAST_PATH) {
-    const { headBuf } = await readHeadOnce(filePath, 64 * 1024);
+    const { headBuf } = await readHeadOnce(workFilePath, 64 * 1024);
     const headSampleBytes = headBuf?.length ?? 0;
     let { encoding } = await detectEncoding(
-      { filePath, headBuf, sampleBytes: headSampleBytes, fallback: "latin1" }
+      { filePath: workFilePath, headBuf, sampleBytes: headSampleBytes, fallback: "latin1" }
     );
 
     let encodingNorm = typeof encoding === "string" ? encoding.toLowerCase() : "utf8";
@@ -169,13 +197,13 @@ export async function createMetadadosController(filePath, action) {
         ? iconv.decode(headForText, "latin1")
         : headForText.toString("utf8");
 
-    const delimiter = await detectDelimiter(filePath, encoding, {
+    const delimiter = await detectDelimiter(workFilePath, encoding, {
       minHeadBytes: headSampleBytes,
       maxHeadBytes: headSampleBytes,
       headText,
       headBytes: headSampleBytes,
     });
-    const rawHeaders = await readCsvHeader(filePath, encoding, delimiter, {
+    const rawHeaders = await readCsvHeader(workFilePath, encoding, delimiter, {
       highWaterMark: 64 * 1024,
       fastMode: true,
     });
@@ -212,7 +240,7 @@ export async function createMetadadosController(filePath, action) {
     return metadados;
   }
 
-  const analise = await analyzeCsv(filePath, destino.tabela_destino);
+  const analise = await analyzeCsv(workFilePath, destino.tabela_destino);
 
   const metadados = {
     nome_arquivo: destino.nome_arquivo,

--- a/src/controller/managerDataController.js
+++ b/src/controller/managerDataController.js
@@ -32,6 +32,7 @@ import { normalizeTotal } from "../utils/normalizeTotal.js";
 
 export async function manageInsertController(metadados, logData) {
   const contexto = metadados.caminho_original;
+  const workPath = metadados.paths?.work || contexto;
   const nomeArquivo = metadados.nome_arquivo ?? "arquivo-desconhecido";
   const barraId = `${nomeArquivo}::${metadados.ano ?? "-"}::${metadados.tabela}`;
 
@@ -82,7 +83,7 @@ export async function manageInsertController(metadados, logData) {
 
     publish(0.1, encoding ? `Encoding: ${encoding}` : "Detectando encoding...");
     if (!encoding) {
-      ({ encoding } = await detectEncoding(contexto));
+      ({ encoding } = await detectEncoding({ filePath: workPath }));
     }
 
     publish(
@@ -92,7 +93,7 @@ export async function manageInsertController(metadados, logData) {
         : `Encoding: ${encoding} | Detectando delimitador...`,
     );
     if (!delimiter) {
-      delimiter = await detectDelimiter(contexto, encoding);
+      delimiter = await detectDelimiter(workPath, encoding);
     }
 
     publish(0.8, `Delimitador: ${delimiter}`);

--- a/src/monitoring.js
+++ b/src/monitoring.js
@@ -18,6 +18,7 @@ import {
   updateDebounceSize,
   updateMetrics as updateQueueMetrics,
 } from "./utils/queueTracker.js";
+import { STAGING_DIR } from "../config/index.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const limit = pLimit(FILES_MAX_CONCURRENT);
@@ -68,6 +69,15 @@ export async function startMonitoring() {
   const awfStability = Number(process.env.AWF_STABILITY_MS || 1500);
   const awfPoll = Number(process.env.AWF_POLL_MS || 100);
 
+  const ignoredPatterns = [/[/\\]database_monitoring[/\\]/, /[/\\]loggers[/\\]/, /\.txt$/];
+  if (STAGING_DIR) {
+    const normalized = path.resolve(STAGING_DIR);
+    ignoredPatterns.push(normalized);
+    if (normalized.includes("\\")) {
+      ignoredPatterns.push(normalized.replace(/\\/g, "/"));
+    }
+  }
+
   const watcher = chokidar.watch(monitorPath, {
     persistent: true,
     ignoreInitial: true,
@@ -76,7 +86,7 @@ export async function startMonitoring() {
     depth: 10,
     atomic: 200,
     ignorePermissionErrors: true,
-    ignored: [/[/\\]database_monitoring[/\\]/, /[/\\]loggers[/\\]/, /\.txt$/],
+    ignored: ignoredPatterns,
     awaitWriteFinish: {
       stabilityThreshold: awfStability,
       pollInterval: awfPoll,

--- a/src/utils/cleanupStaging.js
+++ b/src/utils/cleanupStaging.js
@@ -1,0 +1,82 @@
+import fsp from "fs/promises";
+import path from "path";
+
+function getLogger(logger) {
+  const noop = () => {};
+  const info = logger?.info
+    ? (msg) => {
+        try {
+          logger.info(msg);
+        } catch (_) {}
+      }
+    : noop;
+  const warn = logger?.warn
+    ? (msg) => {
+        try {
+          logger.warn(msg);
+        } catch (_) {}
+      }
+    : info;
+  const error = logger?.error
+    ? (msg) => {
+        try {
+          logger.error(msg);
+        } catch (_) {}
+      }
+    : warn;
+  return { info, warn, error };
+}
+
+export async function cleanupStaging({
+  stagingDir,
+  ttlMinutes,
+  logger,
+} = {}) {
+  if (!stagingDir) return { removed: 0, scanned: 0 };
+  const ttlMs = Math.max(0, Number(ttlMinutes) || 0) * 60 * 1000;
+  if (ttlMs <= 0) return { removed: 0, scanned: 0 };
+
+  const log = getLogger(logger);
+
+  let dirHandle;
+  let removed = 0;
+  let scanned = 0;
+
+  try {
+    dirHandle = await fsp.opendir(stagingDir);
+  } catch (err) {
+    if (err?.code === "ENOENT") return { removed: 0, scanned: 0 };
+    log.warn(`[Staging] cleanup falhou ao abrir diretório (${stagingDir}): ${err.message}`);
+    return { removed: 0, scanned: 0 };
+  }
+
+  const now = Date.now();
+  const staleBefore = now - ttlMs;
+
+  try {
+    for await (const dirent of dirHandle) {
+      if (!dirent || !dirent.isFile?.()) continue;
+      scanned += 1;
+      const filePath = path.join(stagingDir, dirent.name);
+      try {
+        const stats = await fsp.stat(filePath);
+        if (stats.mtimeMs < staleBefore) {
+          await fsp.unlink(filePath);
+          removed += 1;
+        }
+      } catch (err) {
+        if (err?.code === "ENOENT") continue;
+        log.warn(`[Staging] cleanup falhou para ${filePath}: ${err.message}`);
+      }
+    }
+  } finally {
+    await dirHandle.close().catch(() => {});
+  }
+
+  if (removed > 0) {
+    log.info(`[Staging] cleanup removeu ${removed} arquivos antigos (${scanned} verificados)`);
+  }
+
+  return { removed, scanned };
+}
+

--- a/src/utils/ensureLocalStaging.js
+++ b/src/utils/ensureLocalStaging.js
@@ -1,0 +1,364 @@
+import fsp from "fs/promises";
+import os from "os";
+import path from "path";
+import { pipeline } from "stream/promises";
+import { createReadStream, createWriteStream } from "fs";
+import { performance } from "node:perf_hooks";
+
+const DEFAULT_MAX_TOTAL_DELAY_MS = 30_000;
+const RETRY_DELAYS_MS = [200, 500, 1000, 2000, 5000];
+const DEFAULT_STABILITY_INTERVAL_MS = 500;
+const DEFAULT_STABILITY_ROUNDS = 2;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function defaultStagingDir() {
+  return path.join(os.tmpdir(), "database_monitoring", "staging");
+}
+
+function normalizeBoolean(value, defaultValue) {
+  if (value == null) return defaultValue;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const s = value.trim().toLowerCase();
+    if (!s) return defaultValue;
+    if (["1", "true", "yes", "sim", "y"].includes(s)) return true;
+    if (["0", "false", "no", "nao", "não", "n"].includes(s)) return false;
+  }
+  return defaultValue;
+}
+
+function normalizeNumber(value, defaultValue) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : defaultValue;
+}
+
+export function isRemotePath(p) {
+  if (typeof p !== "string" || p.length === 0) return false;
+  if (p.startsWith("\\\\?\\")) {
+    const tail = p.slice(4).toUpperCase();
+    if (tail.startsWith("UNC\\")) return true;
+    return false;
+  }
+  if (p.startsWith("\\\\")) return true;
+  if (p.startsWith("//")) {
+    const rest = p.slice(2);
+    if (!rest) return false;
+    return !rest.startsWith("/");
+  }
+  return false;
+}
+
+function getLogger(logger) {
+  const noop = () => {};
+  const info = logger?.info ? (msg) => {
+    try {
+      logger.info(msg);
+    } catch (_) {}
+  } : noop;
+  const warn = logger?.warn
+    ? (msg) => {
+        try {
+          logger.warn(msg);
+        } catch (_) {}
+      }
+    : info;
+  const error = logger?.error
+    ? (msg) => {
+        try {
+          logger.error(msg);
+        } catch (_) {}
+      }
+    : info;
+  return { info, warn, error };
+}
+
+async function safeStat(p, allowNotFound = false) {
+  try {
+    return await fsp.stat(p);
+  } catch (err) {
+    if (allowNotFound && (err?.code === "ENOENT" || err?.code === "ENOTDIR")) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+function shouldRetry(err) {
+  if (!err) return false;
+  const retryable = new Set([
+    "EBUSY",
+    "EPERM",
+    "EACCES",
+    "EMFILE",
+    "ENFILE",
+    "EIO",
+    "ETXTBSY",
+  ]);
+  if (retryable.has(err.code)) return true;
+  if (err.code === "EINVAL" && err.syscall === "open") return true;
+  return false;
+}
+
+function shouldFallbackToStream(err) {
+  if (!err) return false;
+  return ["ERR_FS_FILE_TOO_LARGE", "ENOSYS", "EXDEV", "ENOTSUP"].includes(err.code);
+}
+
+async function copyViaStream(src, dest, highWaterMark = 8 * 1024 * 1024) {
+  await pipeline(
+    createReadStream(src, { highWaterMark }),
+    createWriteStream(dest, { highWaterMark })
+  );
+  return "stream";
+}
+
+async function attemptCopy(src, dest) {
+  try {
+    await fsp.copyFile(src, dest);
+    return "copyFile";
+  } catch (err) {
+    if (shouldFallbackToStream(err)) {
+      return await copyViaStream(src, dest);
+    }
+    throw err;
+  }
+}
+
+async function ensureDir(dir) {
+  if (!dir) return;
+  await fsp.mkdir(dir, { recursive: true });
+}
+
+async function waitForStableFile(srcPath, { logger, intervalMs, rounds }) {
+  const log = getLogger(logger);
+  const stableRounds = Math.max(1, rounds | 0);
+  let prev = await safeStat(srcPath);
+  if (!prev) throw new Error(`Arquivo de origem não encontrado: ${srcPath}`);
+  let stableCount = 0;
+  for (let i = 0; i < 10; i++) {
+    await sleep(intervalMs);
+    const next = await safeStat(srcPath);
+    if (!next) throw new Error(`Arquivo de origem inacessível: ${srcPath}`);
+    if (next.size === prev.size && Math.abs(next.mtimeMs - prev.mtimeMs) < 1) {
+      stableCount += 1;
+      if (stableCount >= stableRounds) {
+        return next;
+      }
+    } else {
+      stableCount = 0;
+      log.info(
+        `[Staging] aguardando estabilizar: size mudou de ${prev.size} para ${next.size} bytes`
+      );
+    }
+    prev = next;
+  }
+  log.warn("[Staging] estabilidade não confirmada após múltiplas tentativas, prosseguindo assim mesmo");
+  return prev;
+}
+
+async function ensureDiskSpace(dir, requiredBytes, minFreeMb, logger) {
+  if (!(minFreeMb > 0)) return;
+  if (!dir) return;
+  if (typeof fsp.statfs !== "function") {
+    getLogger(logger).warn(
+      `[Staging] statfs indisponível para verificar espaço em disco, prosseguindo sem validação`
+    );
+    return;
+  }
+  try {
+    const stats = await fsp.statfs(dir);
+    const freeBytes = Number(stats?.bavail) * Number(stats?.bsize);
+    if (!Number.isFinite(freeBytes)) return;
+    const freeMb = freeBytes / (1024 * 1024);
+    if (freeMb < minFreeMb) {
+      const message = `Espaço insuficiente no staging (${freeMb.toFixed(1)}MB disponível, requer ${minFreeMb}MB)`;
+      throw new Error(message);
+    }
+    if (requiredBytes && freeBytes < requiredBytes) {
+      const needMb = (requiredBytes / (1024 * 1024)).toFixed(1);
+      const msg = `Espaço insuficiente no staging (necessário ${needMb}MB, disponível ${freeMb.toFixed(1)}MB)`;
+      throw new Error(msg);
+    }
+  } catch (err) {
+    if (err?.code === "ENOENT") return;
+    if (err?.code === "ENOSYS") {
+      getLogger(logger).warn(
+        `[Staging] statfs não suportado ao verificar espaço em disco, prosseguindo`
+      );
+      return;
+    }
+    throw err;
+  }
+}
+
+function buildDeterministicName(srcPath, stats) {
+  const parsed = path.parse(srcPath);
+  const base = parsed.name || "arquivo";
+  const ext = parsed.ext || ".csv";
+  const sizePart = Number(stats?.size ?? 0);
+  const mtimePart = Math.floor(Number(stats?.mtimeMs ?? 0));
+  const safeBase = base.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return `${safeBase}.${sizePart}.${mtimePart}${ext}`;
+}
+
+function computeRetryDelay(attempt) {
+  if (attempt < RETRY_DELAYS_MS.length) return RETRY_DELAYS_MS[attempt];
+  return RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1];
+}
+
+export async function ensureLocalStaging({
+  srcPath,
+  stagingDir = process.env.STAGING_DIR || defaultStagingDir(),
+  reuse = normalizeBoolean(process.env.STAGING_REUSE, true),
+  verify = normalizeBoolean(process.env.STAGING_VERIFY, true),
+  logger,
+} = {}) {
+  if (!srcPath || typeof srcPath !== "string") {
+    throw new Error("Caminho de origem inválido para staging");
+  }
+
+  const log = getLogger(logger);
+  const remote = isRemotePath(srcPath);
+
+  if (!remote) {
+    log.info(`[Staging] origem local detectada, uso direto do arquivo (${srcPath})`);
+    return {
+      effectivePath: srcPath,
+      copied: false,
+      reused: false,
+      isRemote: false,
+      bytes: 0,
+      durationMs: 0,
+      retries: 0,
+      method: null,
+      verify,
+      stagingDir,
+    };
+  }
+
+  const start = performance.now();
+  const stabilityInterval = normalizeNumber(
+    process.env.STAGING_STABILITY_INTERVAL_MS,
+    DEFAULT_STABILITY_INTERVAL_MS
+  );
+  const stabilityRounds = normalizeNumber(
+    process.env.STAGING_STABILITY_ROUNDS,
+    DEFAULT_STABILITY_ROUNDS
+  );
+  const minFreeMb = normalizeNumber(process.env.STAGING_DISK_MIN_MB, 0);
+
+  log.info(
+    `[Staging] início | src="${srcPath}" | stagingDir="${stagingDir}" | reuse=${reuse} | verify=${verify}`
+  );
+
+  await ensureDir(stagingDir);
+
+  const srcStats = await waitForStableFile(srcPath, {
+    logger,
+    intervalMs: Math.max(100, stabilityInterval),
+    rounds: Math.max(1, stabilityRounds),
+  });
+
+  await ensureDiskSpace(stagingDir, srcStats.size, minFreeMb, logger);
+
+  const fileName = buildDeterministicName(srcPath, srcStats);
+  const destPath = path.join(stagingDir, fileName);
+
+  if (reuse) {
+    const existing = await safeStat(destPath, true);
+    if (existing && existing.size === srcStats.size) {
+      log.info(
+        `[Staging] reutilizando cópia existente (${destPath}) | bytes=${existing.size}`
+      );
+      return {
+        effectivePath: destPath,
+        copied: false,
+        reused: true,
+        isRemote: true,
+        bytes: existing.size,
+        durationMs: performance.now() - start,
+        retries: 0,
+        method: "reuse",
+        verify,
+        stagingDir,
+      };
+    }
+  }
+
+  const tempPath = destPath + ".tmp-" + process.pid;
+  let attempt = 0;
+  let retries = 0;
+  let lastError = null;
+  let method = "copyFile";
+  let totalDelay = 0;
+
+  while (true) {
+    try {
+      await ensureDir(path.dirname(destPath));
+      await fsp.unlink(destPath).catch(() => {});
+      method = await attemptCopy(srcPath, tempPath);
+      await fsp.utimes(tempPath, srcStats.atime ?? new Date(), srcStats.mtime ?? new Date());
+      await fsp.rename(tempPath, destPath);
+      break;
+    } catch (err) {
+      lastError = err;
+      try {
+        await fsp.unlink(tempPath);
+      } catch (_) {}
+      if (!shouldRetry(err) || totalDelay >= DEFAULT_MAX_TOTAL_DELAY_MS) {
+        log.error(`[Staging] falha ao copiar arquivo: ${err?.message || err}`);
+        throw err;
+      }
+      const delay = computeRetryDelay(attempt);
+      totalDelay += delay;
+      retries += 1;
+      log.warn(
+        `[Staging] tentativa ${attempt + 1} falhou (${err?.code || err?.message}); aguardando ${delay}ms para retry`
+      );
+      await sleep(delay);
+      attempt += 1;
+    }
+  }
+
+  const destStats = await safeStat(destPath);
+  if (!destStats) {
+    const err = new Error("Falha ao localizar cópia após staging");
+    log.error(`[Staging] ${err.message}`);
+    throw err;
+  }
+
+  if (verify) {
+    if (destStats.size !== srcStats.size) {
+      const err = new Error(
+        `Verificação falhou: bytes diferentes (origem=${srcStats.size}, cópia=${destStats.size})`
+      );
+      log.error(`[Staging] ${err.message}`);
+      await fsp.unlink(destPath).catch(() => {});
+      throw err;
+    }
+  }
+
+  const durationMs = performance.now() - start;
+  log.info(
+    `[Staging] concluído | work="${destPath}" | bytes=${destStats.size} | duration=${durationMs.toFixed(0)}ms | retries=${retries} | method=${method}`
+  );
+
+  return {
+    effectivePath: destPath,
+    copied: true,
+    reused: false,
+    isRemote: true,
+    bytes: destStats.size,
+    durationMs,
+    retries,
+    method,
+    verify,
+    stagingDir,
+    lastError,
+  };
+}
+

--- a/src/utils/streamPipeline.js
+++ b/src/utils/streamPipeline.js
@@ -62,6 +62,7 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}, pipelineO
     encoding,
     delimiter,
   } = metadados;
+  const workPath = metadados.paths?.work || contexto;
   
   memoryGuard.start();
 
@@ -195,7 +196,7 @@ export async function streamPipeline(metadados, tiposFinal, opts = {}, pipelineO
     updateActiveJob(contexto, { detail: `Enviando lote (${lote.length} linhas)` });
   }
 
-  const { forHash, forParse } = createFileTee(contexto, { highWaterMark: HWM });
+  const { forHash, forParse } = createFileTee(workPath, { highWaterMark: HWM });
   let hash;
   if (computeHash) {
     hash = crypto.createHash("sha256");


### PR DESCRIPTION
## Summary
- add utilities to stage remote CSVs locally with retries, disk verification, and optional cleanup helpers
- integrate staging into the ingestion handler and pipeline so analysis and streaming operate on the staged work path recorded in `metadados.paths`
- expose staging environment settings and exclude the staging directory from the watcher to avoid feedback loops

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9c1bc7e248324a748803984019bc1