### PR TITLE
Integrate structured logging blocks

### DIFF
--- a/src/controller/Handlers/createdHandler.js
+++ b/src/controller/Handlers/createdHandler.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { addAviso, addErro, addInfo } from "../../middleware/errorHandler.js";
 import { insertLog } from "../../model/logModel.js";
 import createDataController from "../createDataController.js";
@@ -16,6 +17,12 @@ import { markJobComplete } from "../../utils/queueTracker.js";
 import { ensureLocalStaging } from "../../utils/ensureLocalStaging.js";
 import { cleanupStaging } from "../../utils/cleanupStaging.js";
 import { unlink } from "fs/promises";
+import {
+  startLogger,
+  writeBeginFile,
+  writeFinal,
+  endLogger,
+} from "../../middleware/logger.js";
 
 function parseBoolean(value, defaultValue) {
   if (value == null) return defaultValue;
@@ -62,12 +69,46 @@ export default async function createdHandler(filePath, action, job) {
     return;
   }
 
-  await withFileLifecycle(
-    filePath,
-    async () => {
-      const stagingLogger = createStagingLogger(filePath);
-      const reuse = parseBoolean(STAGING_REUSE, true);
-      const verify = parseBoolean(STAGING_VERIFY, true);
+  let loggerEntry = null;
+  const arquivo = filePath ? path.basename(filePath) : "";
+  try {
+    try {
+      loggerEntry = startLogger(filePath, {
+        overwrite: true,
+        disableBeginLine: true,
+        disableEndLine: true,
+      });
+    } catch (err) {
+      addAviso(
+        `[Logger] não foi possível iniciar logger dedicado: ${err?.message || err}`,
+        filePath,
+      );
+    }
+
+    if (loggerEntry) {
+      try {
+        await writeBeginFile({
+          filePath,
+          arquivo: arquivo || "—",
+          tabela: "—",
+          dataStr: "—",
+          acao: "analyze",
+          hash: "—",
+        });
+      } catch (err) {
+        addAviso(
+          `[Logger] não foi possível registrar bloco inicial: ${err?.message || err}`,
+          filePath,
+        );
+      }
+    }
+
+    await withFileLifecycle(
+      filePath,
+      async () => {
+        const stagingLogger = createStagingLogger(filePath);
+        const reuse = parseBoolean(STAGING_REUSE, true);
+        const verify = parseBoolean(STAGING_VERIFY, true);
       const cleanupOnSuccess = parseBoolean(STAGING_CLEANUP_ON_SUCCESS, true);
       const cleanupTtlMin = parseNumber(STAGING_CLEANUP_TTL_MIN, 120);
       const stagingDirEnv =
@@ -185,7 +226,28 @@ export default async function createdHandler(filePath, action, job) {
           }
         }
       }
-    },
-    { job, action }
-  );
+      },
+      { job, action, manageLogger: false }
+    );
+  } finally {
+    if (loggerEntry) {
+      try {
+        await writeFinal({ filePath });
+      } catch (err) {
+        addAviso(
+          `[Logger] não foi possível registrar bloco final: ${err?.message || err}`,
+          filePath,
+        );
+      }
+    }
+
+    try {
+      await endLogger(filePath);
+    } catch (err) {
+      addAviso(
+        `[Logger] não foi possível encerrar logger dedicado: ${err?.message || err}`,
+        filePath,
+      );
+    }
+  }
 }

--- a/src/controller/createDataController.js
+++ b/src/controller/createDataController.js
@@ -20,7 +20,7 @@ import {
 } from "../model/tableModel.js";
 import { PIPELINE_FAST_PATH } from "../../config/index.js";
 import { decideOverlapPolicy } from "../utils/decideOverlapPolicy.js";
-import { logActivity } from "../middleware/logger.js";
+import { logActivity, writeHeadersDiff, shortPath } from "../middleware/logger.js";
 import { isRemotePath } from "../utils/ensureLocalStaging.js";
 
 /* ---------- hot helpers ---------- */
@@ -91,6 +91,51 @@ export function truncarFilepath(fullpath) {
   }
 
   return s;
+}
+
+function inferTabelaFromContexto(contexto, fallback = "—") {
+  if (!contexto) return fallback;
+  const match = String(contexto).match(/[\\/](\d{2}_\d{2}_\d{2})[\\/](\d{4})[\\/][^\\/]+$/);
+  if (match && match[1]) {
+    return match[1];
+  }
+  return fallback;
+}
+
+function computeHeadersDiff(headersCsv, headersTabela) {
+  const csv = Array.isArray(headersCsv) ? headersCsv : [];
+  const tabela = Array.isArray(headersTabela) ? headersTabela : [];
+  const tabelaSet = new Set(tabela.map((h) => String(h ?? "")));
+  const csvSet = new Set(csv.map((h) => String(h ?? "")));
+  const extras = csv.map((h) => String(h ?? "")).filter((h) => !tabelaSet.has(h));
+  const missing = tabela.map((h) => String(h ?? "")).filter((h) => !csvSet.has(h));
+  return { extras, missing };
+}
+
+async function logHeadersComparison({ contexto, tabela, headersCsv, headersTabela }) {
+  if (!Array.isArray(headersCsv) || !Array.isArray(headersTabela)) return;
+  const tabelaSafe = tabela || inferTabelaFromContexto(contexto);
+  try {
+    await writeHeadersDiff({
+      filePath: contexto,
+      tabela: tabelaSafe || inferTabelaFromContexto(contexto),
+      headersCsv,
+      headersTabela,
+    });
+
+    const { extras, missing } = computeHeadersDiff(headersCsv, headersTabela);
+    if (extras.length === 0 && missing.length === 0) {
+      addInfo("[Headers] CSV e tabela estão alinhados.", contexto);
+    }
+  } catch (err) {
+    const shortCtx = shortPath(contexto || "");
+    addAviso(
+      `[Headers] não foi possível gerar comparativo (${shortCtx || "—"}): ${
+        err?.message || err
+      }`,
+      contexto,
+    );
+  }
 }
 
 /* ---------- controllers ---------- */
@@ -236,6 +281,13 @@ export async function createMetadadosController(filePath, action, opts = {}) {
       caminho_truncado,
     };
 
+    await logHeadersComparison({
+      contexto: filePath,
+      tabela: metadados.tabela,
+      headersCsv: metadados.colunas_json,
+      headersTabela: metadados.colunas_tabela,
+    });
+
     await ensureOverlapMetadata(metadados, filePath, action);
     return metadados;
   }
@@ -263,6 +315,13 @@ export async function createMetadadosController(filePath, action, opts = {}) {
     caminho_original: filePath,
     caminho_truncado,
   };
+
+  await logHeadersComparison({
+    contexto: filePath,
+    tabela: metadados.tabela,
+    headersCsv: metadados.colunas_json,
+    headersTabela: metadados.colunas_tabela,
+  });
 
   await ensureOverlapMetadata(metadados, filePath, action);
   return metadados;

--- a/src/controller/managerDataController.js
+++ b/src/controller/managerDataController.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { deleteFromTable, buildRangeFromMetadados } from "../model/tableModel.js";
 import {
   iniciarBarra,
@@ -6,7 +7,7 @@ import {
 } from "../utils/progressBar.js";
 
 import { addAviso, addErro, addInfo } from "../middleware/errorHandler.js";
-import { logActivity } from "../middleware/logger.js";
+import { logActivity, writeStatusUpdate } from "../middleware/logger.js";
 import { decideOverlapPolicy } from "../utils/decideOverlapPolicy.js";
 import streamPipeline, {
   POOL_MAX,
@@ -253,6 +254,46 @@ export async function manageInsertController(metadados, logData) {
       }
 
       addInfo("Processo de inserção finalizado.", contexto);
+      try {
+        const arquivo = path.basename(contexto || "");
+        const tabelaFin =
+          metadados?.destino?.tabela_destino || metadados?.tabela || "—";
+        const overlapStrategy =
+          metadados?.overlap?.strategy || metadados?.manage?.usingStrategy;
+
+        const range = metadados?.range || metadados?.manage?.range;
+        const dataStr = (() => {
+          if (!range?.start) return "—";
+          const d = new Date(range.start);
+          const y = d.getFullYear();
+          const mes = new Intl.DateTimeFormat("pt-BR", {
+            month: "long",
+            timeZone: "America/Sao_Paulo",
+          })
+            .format(d)
+            .toLowerCase();
+          return `${y}-${mes}-—`;
+        })();
+
+        const acao =
+          metadados?.arquivoAlterado || overlapStrategy === "replace"
+            ? "modified"
+            : "insert";
+
+        await writeStatusUpdate({
+          filePath: contexto,
+          arquivo,
+          tabela: tabelaFin,
+          dataStr,
+          acao,
+          hash: metadados?.hash || "—",
+        });
+      } catch (err) {
+        addAviso(
+          `[Status] não foi possível registrar atualização: ${err?.message || err}`,
+          contexto,
+        );
+      }
       void logActivity("info", "Pipeline de streaming concluído", { filePath: contexto });
       updateActiveJob(contexto, { stage: "finalização", progress: 1, detail: "Processo concluído" });
 

--- a/src/middleware/logger.js
+++ b/src/middleware/logger.js
@@ -205,6 +205,7 @@ export function startLogger(filePath, options = {}) {
     flushIntervalMs = FLUSH_MS,
     highWaterMark = 1024 * 256,
     disableBeginLine = true,
+    disableEndLine = false,
     displayName,
     overwrite = true,
   } = options;
@@ -231,6 +232,7 @@ export function startLogger(filePath, options = {}) {
     ended: false,
     endPromise: null,
     displayName: displayName || path.basename(filePath) || filePath,
+    disableEndLine: Boolean(disableEndLine),
   };
 
   stream.on("error", (err) => {
@@ -490,8 +492,10 @@ export async function endLogger(filePath) {
       }
 
       if (!entry.ended && !entry.stream.destroyed) {
-        entry.buffer.push(formatLine("info", `==== END ${entry.displayName} ====`));
-        await flush(filePath).catch(err => {
+        if (!entry.disableEndLine) {
+          entry.buffer.push(formatLine("info", `==== END ${entry.displayName} ====`));
+        }
+        await flush(filePath).catch((err) => {
           console.error(`[logger] flush final falhou (${entry.displayName}):`, err?.message || err);
         });
       }

--- a/src/utils/withFileLifecycle.js
+++ b/src/utils/withFileLifecycle.js
@@ -15,7 +15,11 @@ export function getActiveFilesCount() {
 }
 
 export async function withFileLifecycle(filePath, fn, lifecycleOpts = {}) {
-  startLogger(filePath);
+  const { manageLogger = true, loggerOptions } = lifecycleOpts;
+
+  if (manageLogger !== false) {
+    startLogger(filePath, loggerOptions);
+  }
   activeFiles.add(filePath);
 
   const { job: rawJob, action } = lifecycleOpts;
@@ -45,7 +49,9 @@ export async function withFileLifecycle(filePath, fn, lifecycleOpts = {}) {
     throw err;
   } finally {
     try {
-      await endLogger(filePath);
+      if (manageLogger !== false) {
+        await endLogger(filePath);
+      }
     } catch (err) {
       console.error(`[logger] Falha ao finalizar logger de ${filePath}:`, err?.message || err);
     } finally {


### PR DESCRIPTION
## Summary
- initialize per-file loggers in the creation handler with BEGIN/FINAL blocks and ensure cleanup even on failures
- emit CSV versus table header comparisons with clear fallback handling and alignment message
- record status update blocks after insert completion and support optional logger management utilities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb0aa75cd0832492f3465191b155fa