### PR TITLE
Optimize logger aggregation and staging

### DIFF
--- a/src/controller/Handlers/createdHandler.js
+++ b/src/controller/Handlers/createdHandler.js
@@ -1,5 +1,10 @@
 import path from "path";
-import { addAviso, addErro, addInfo } from "../../middleware/errorHandler.js";
+import {
+  addAviso,
+  addErro,
+  addInfo,
+  flushAggregatedSummaries,
+} from "../../middleware/errorHandler.js";
 import { insertLog } from "../../model/logModel.js";
 import createDataController from "../createDataController.js";
 import fluxoValidatorController from "../fluxoValidatorController.js";
@@ -16,13 +21,18 @@ import { withFileLifecycle } from "../../utils/withFileLifecycle.js";
 import { markJobComplete } from "../../utils/queueTracker.js";
 import { ensureLocalStaging } from "../../utils/ensureLocalStaging.js";
 import { cleanupStaging } from "../../utils/cleanupStaging.js";
-import { unlink } from "fs/promises";
+import { unlink as unlinkFile } from "fs/promises";
 import {
   startLogger,
   writeBeginFile,
   writeFinal,
   endLogger,
 } from "../../middleware/logger.js";
+import {
+  finalizeStagedLogger,
+  setupStagedLogger,
+  shouldStageLogger,
+} from "../../utils/loggerStaging.js";
 
 function parseBoolean(value, defaultValue) {
   if (value == null) return defaultValue;
@@ -70,19 +80,48 @@ export default async function createdHandler(filePath, action, job) {
   }
 
   let loggerEntry = null;
+  let stagedLoggerInfo = null;
   const arquivo = filePath ? path.basename(filePath) : "";
   try {
+    const loggerOptions = {
+      overwrite: true,
+      disableBeginLine: true,
+      disableEndLine: true,
+    };
+
+    if (shouldStageLogger(filePath)) {
+      try {
+        stagedLoggerInfo = await setupStagedLogger(filePath);
+        if (stagedLoggerInfo?.localLogPath) {
+          loggerOptions.logPath = stagedLoggerInfo.localLogPath;
+        }
+      } catch (err) {
+        stagedLoggerInfo = null;
+        addAviso(
+          `[Logger] não foi possível preparar log local temporário: ${err?.message || err}`,
+          filePath,
+        );
+      }
+    }
+
     try {
-      loggerEntry = startLogger(filePath, {
-        overwrite: true,
-        disableBeginLine: true,
-        disableEndLine: true,
-      });
+      loggerEntry = startLogger(filePath, loggerOptions);
     } catch (err) {
       addAviso(
         `[Logger] não foi possível iniciar logger dedicado: ${err?.message || err}`,
         filePath,
       );
+      if (stagedLoggerInfo) {
+        try {
+          await finalizeStagedLogger(stagedLoggerInfo, { skipCopy: true });
+        } catch (cleanupErr) {
+          addAviso(
+            `[Logger] não foi possível remover arquivo de início do processamento: ${cleanupErr?.message || cleanupErr}`,
+            filePath,
+          );
+        }
+        stagedLoggerInfo = null;
+      }
     }
 
     if (loggerEntry) {
@@ -109,128 +148,136 @@ export default async function createdHandler(filePath, action, job) {
         const stagingLogger = createStagingLogger(filePath);
         const reuse = parseBoolean(STAGING_REUSE, true);
         const verify = parseBoolean(STAGING_VERIFY, true);
-      const cleanupOnSuccess = parseBoolean(STAGING_CLEANUP_ON_SUCCESS, true);
-      const cleanupTtlMin = parseNumber(STAGING_CLEANUP_TTL_MIN, 120);
-      const stagingDirEnv =
-        typeof STAGING_DIR === "string" && STAGING_DIR.trim().length > 0
-          ? STAGING_DIR.trim()
-          : undefined;
+        const cleanupOnSuccess = parseBoolean(STAGING_CLEANUP_ON_SUCCESS, true);
+        const cleanupTtlMin = parseNumber(STAGING_CLEANUP_TTL_MIN, 120);
+        const stagingDirEnv =
+          typeof STAGING_DIR === "string" && STAGING_DIR.trim().length > 0
+            ? STAGING_DIR.trim()
+            : undefined;
 
-      let stagingInfo = null;
-      let metadados;
-      let logData;
-      let processingSucceeded = false;
-
-      try {
-        try {
-          stagingInfo = await ensureLocalStaging({
-            srcPath: filePath,
-            stagingDir: stagingDirEnv,
-            reuse,
-            verify,
-            logger: stagingLogger,
-          });
-        } catch (err) {
-          addErro(
-            `[Staging] falha ao preparar cópia local: ${err?.message || err}`,
-            filePath
-          );
-          return;
-        }
-
-        const workFilePath = stagingInfo?.effectivePath || filePath;
+        let stagingInfo = null;
+        let metadados;
+        let logData;
+        let processingSucceeded = false;
 
         try {
-          const result = await createDataController(filePath, action, {
-            workFilePath,
-            stagingInfo,
-          });
-          ({ metadados, logData } = result || {});
-        } catch (e) {
-          addErro(`erro ao gerar os dados fundamentais, erro:${e.message}`, filePath);
-          return;
-        }
-
-        if (!metadados || !logData) {
-          addErro("metadados ou logData não foram gerados corretamente", filePath);
-          return;
-        }
-
-        let fluxo;
-        try {
-          fluxo = await fluxoValidatorController(metadados, logData);
-        } catch (e) {
-          addErro(`Erro ao validar fluxo de ingestão: ${e.message}`, filePath);
-          return;
-        }
-
-        if (fluxo !== "inserir" && fluxo !== "reprocessar") {
-          addInfo(
-            `[ARQUIVO IGNORADO] ${metadados.nome_arquivo} já existe e não foi modificado.`,
-            filePath
-          );
-          await insertLog(logData);
-          processingSucceeded = true;
-          return;
-        }
-
-        try {
-          const resultado = await manageInsertController(metadados, logData);
-          logData.sucesso = !resultado?.erro;
-          logData.mensagem_erro = resultado?.mensagem || null;
-          logData.hash_arquivo = metadados.hash;
-          logData.total_linhas = metadados.total_linhas;
-          if (resultado?.erro) addErro(logData.mensagem_erro, filePath);
-        } catch (e) {
-          logData.sucesso = false;
-          logData.mensagem_erro = `Erro durante execução do managerDataController: ${e.message}`;
-          addErro(logData.mensagem_erro, filePath);
-        } finally {
-          await insertLog(logData);
-        }
-
-        processingSucceeded = Boolean(logData?.sucesso);
-      } finally {
-        if (stagingInfo && stagingInfo.isRemote && stagingInfo.effectivePath) {
-          const isDifferentPath = stagingInfo.effectivePath !== filePath;
-          const hasCopy = stagingInfo.copied || stagingInfo.reused;
-          if (isDifferentPath && hasCopy) {
-            if (processingSucceeded && cleanupOnSuccess) {
-              try {
-                await unlink(stagingInfo.effectivePath);
-                stagingLogger.info(
-                  `cópia local removida após sucesso (${stagingInfo.effectivePath})`
-                );
-              } catch (err) {
-                stagingLogger.warn(
-                  `falha ao remover cópia local (${stagingInfo.effectivePath}): ${err?.message || err}`
-                );
-              }
-            } else if (!processingSucceeded) {
-              stagingLogger.info(
-                `mantendo cópia local para análise (${stagingInfo.effectivePath})`
-              );
-            }
-          }
-        }
-
-        if (stagingInfo?.stagingDir) {
           try {
-            await cleanupStaging({
-              stagingDir: stagingInfo.stagingDir,
-              ttlMinutes: cleanupTtlMin,
+            stagingInfo = await ensureLocalStaging({
+              srcPath: filePath,
+              stagingDir: stagingDirEnv,
+              reuse,
+              verify,
               logger: stagingLogger,
             });
           } catch (err) {
-            stagingLogger.warn(`cleanup tardio falhou: ${err?.message || err}`);
+            addErro(
+              `[Staging] falha ao preparar cópia local: ${err?.message || err}`,
+              filePath
+            );
+            return;
+          }
+
+          const workFilePath = stagingInfo?.effectivePath || filePath;
+
+          try {
+            const result = await createDataController(filePath, action, {
+              workFilePath,
+              stagingInfo,
+            });
+            ({ metadados, logData } = result || {});
+          } catch (e) {
+            addErro(`erro ao gerar os dados fundamentais, erro:${e.message}`, filePath);
+            return;
+          }
+
+          if (!metadados || !logData) {
+            addErro("metadados ou logData não foram gerados corretamente", filePath);
+            return;
+          }
+
+          let fluxo;
+          try {
+            fluxo = await fluxoValidatorController(metadados, logData);
+          } catch (e) {
+            addErro(`Erro ao validar fluxo de ingestão: ${e.message}`, filePath);
+            return;
+          }
+
+          if (fluxo !== "inserir" && fluxo !== "reprocessar") {
+            addInfo(
+              `[ARQUIVO IGNORADO] ${metadados.nome_arquivo} já existe e não foi modificado.`,
+              filePath
+            );
+            await insertLog(logData);
+            processingSucceeded = true;
+            return;
+          }
+
+          try {
+            const resultado = await manageInsertController(metadados, logData);
+            logData.sucesso = !resultado?.erro;
+            logData.mensagem_erro = resultado?.mensagem || null;
+            logData.hash_arquivo = metadados.hash;
+            logData.total_linhas = metadados.total_linhas;
+            if (resultado?.erro) addErro(logData.mensagem_erro, filePath);
+          } catch (e) {
+            logData.sucesso = false;
+            logData.mensagem_erro = `Erro durante execução do managerDataController: ${e.message}`;
+            addErro(logData.mensagem_erro, filePath);
+          } finally {
+            await insertLog(logData);
+          }
+
+          processingSucceeded = Boolean(logData?.sucesso);
+        } finally {
+          if (stagingInfo && stagingInfo.isRemote && stagingInfo.effectivePath) {
+            const isDifferentPath = stagingInfo.effectivePath !== filePath;
+            const hasCopy = stagingInfo.copied || stagingInfo.reused;
+            if (isDifferentPath && hasCopy) {
+              if (processingSucceeded && cleanupOnSuccess) {
+                try {
+                  await unlinkFile(stagingInfo.effectivePath);
+                  stagingLogger.info(
+                    `cópia local removida após sucesso (${stagingInfo.effectivePath})`
+                  );
+                } catch (err) {
+                  stagingLogger.warn(
+                    `falha ao remover cópia local (${stagingInfo.effectivePath}): ${err?.message || err}`
+                  );
+                }
+              } else if (!processingSucceeded) {
+                stagingLogger.info(
+                  `mantendo cópia local para análise (${stagingInfo.effectivePath})`
+                );
+              }
+            }
+          }
+
+          if (stagingInfo?.stagingDir) {
+            try {
+              await cleanupStaging({
+                stagingDir: stagingInfo.stagingDir,
+                ttlMinutes: cleanupTtlMin,
+                logger: stagingLogger,
+              });
+            } catch (err) {
+              stagingLogger.warn(`cleanup tardio falhou: ${err?.message || err}`);
+            }
           }
         }
-      }
       },
       { job, action, manageLogger: false }
     );
   } finally {
     if (loggerEntry) {
+      try {
+        await flushAggregatedSummaries(filePath);
+      } catch (err) {
+        addAviso(
+          `[Logger] não foi possível registrar resumos de erros/avisos: ${err?.message || err}`,
+          filePath,
+        );
+      }
       try {
         await writeFinal({ filePath });
       } catch (err) {
@@ -248,6 +295,17 @@ export default async function createdHandler(filePath, action, job) {
         `[Logger] não foi possível encerrar logger dedicado: ${err?.message || err}`,
         filePath,
       );
+    }
+
+    if (stagedLoggerInfo) {
+      try {
+        await finalizeStagedLogger(stagedLoggerInfo);
+      } catch (err) {
+        addAviso(
+          `[Logger] Falha ao copiar log final para a rede: ${err?.message || err}`,
+          filePath,
+        );
+      }
     }
   }
 }

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -3,6 +3,17 @@ import { logLine, shortPath, shortenPathsInMsg } from "./logger.js";
 
 const contextoDeMensagens = new Map();
 
+function createBag() {
+  return {
+    erros: [],
+    infos: [],
+    avisos: [],
+    countErros: new Map(),
+    countAvisos: new Map(),
+    summariesFlushed: false,
+  };
+}
+
 /* ─────────────────────────────── */
 /* Função central de log           */
 /* ─────────────────────────────── */
@@ -23,7 +34,7 @@ async function safeAppendToLog(contexto, tipo, msg) {
 /* ─────────────────────────────── */
 function ensureContext(contexto) {
   if (!contextoDeMensagens.has(contexto)) {
-    contextoDeMensagens.set(contexto, { erros: [], infos: [], avisos: [] });
+    contextoDeMensagens.set(contexto, createBag());
   }
   return contextoDeMensagens.get(contexto);
 }
@@ -31,7 +42,11 @@ function ensureContext(contexto) {
 export function addErro(msg, contexto = "__global") {
   const bag = ensureContext(contexto);
   bag.erros.push(msg);
-  void safeAppendToLog(contexto, "erro", msg);
+  const nextCount = (bag.countErros.get(msg) || 0) + 1;
+  bag.countErros.set(msg, nextCount);
+  if (nextCount <= 5) {
+    void safeAppendToLog(contexto, "erro", msg);
+  }
 }
 
 export function addInfo(msg, contexto = "__global") {
@@ -43,20 +58,58 @@ export function addInfo(msg, contexto = "__global") {
 export function addAviso(msg, contexto = "__global") {
   const bag = ensureContext(contexto);
   bag.avisos.push(msg);
-  void safeAppendToLog(contexto, "aviso", msg);
+  const nextCount = (bag.countAvisos.get(msg) || 0) + 1;
+  bag.countAvisos.set(msg, nextCount);
+  if (nextCount <= 5) {
+    void safeAppendToLog(contexto, "aviso", msg);
+  }
 }
 
 /* ─────────────────────────────── */
 /* Utilitários                     */
 /* ─────────────────────────────── */
 export function getAllErrors(contexto = "__global") {
-  return (
-    contextoDeMensagens.get(contexto) || { erros: [], infos: [], avisos: [] }
-  );
+  return contextoDeMensagens.get(contexto) || createBag();
 }
 export function clearAllErrors(contexto = "__global") {
-  contextoDeMensagens.set(contexto, { erros: [], infos: [], avisos: [] });
+  contextoDeMensagens.set(contexto, createBag());
 }
 export function clearAllContexts() {
   contextoDeMensagens.clear();
+}
+
+export async function flushAggregatedSummaries(contexto = "__global") {
+  const bag = ensureContext(contexto);
+  if (!bag || bag.summariesFlushed) return;
+
+  const summaryEntries = [];
+
+  for (const [msg, count] of bag.countErros.entries()) {
+    if (count > 5) {
+      const remaining = count - 5;
+      const summary = `Mais ${remaining} linhas apresentaram o mesmo erro acima: ${msg}. (Total: ${count} ocorrências)`;
+      bag.erros.push(summary);
+      summaryEntries.push({ tipo: "erro", texto: summary });
+    }
+  }
+
+  for (const [msg, count] of bag.countAvisos.entries()) {
+    if (count > 5) {
+      const remaining = count - 5;
+      const summary = `Mais ${remaining} linhas apresentaram o mesmo aviso acima: ${msg}. (Total: ${count} ocorrências)`;
+      bag.avisos.push(summary);
+      summaryEntries.push({ tipo: "aviso", texto: summary });
+    }
+  }
+
+  bag.summariesFlushed = true;
+
+  await Promise.all(
+    summaryEntries.map(({ tipo, texto }) => safeAppendToLog(contexto, tipo, texto))
+  );
+}
+
+export async function flushAllAggregatedSummaries() {
+  const contexts = Array.from(contextoDeMensagens.keys());
+  await Promise.all(contexts.map((ctx) => flushAggregatedSummaries(ctx)));
 }

--- a/src/utils/loggerStaging.js
+++ b/src/utils/loggerStaging.js
@@ -1,0 +1,61 @@
+import fs from "fs";
+import path from "path";
+import { copyFile, mkdir, unlink, writeFile } from "fs/promises";
+import { isRemotePath } from "./ensureLocalStaging.js";
+
+const LOCAL_LOG_DIR = path.resolve(process.cwd(), "staging_loggers");
+fs.mkdirSync(LOCAL_LOG_DIR, { recursive: true });
+
+export function getLogBaseName(filePath) {
+  if (!filePath) return "log";
+  const parsed = path.parse(filePath);
+  return parsed.name || path.basename(filePath) || "log";
+}
+
+export function shouldStageLogger(filePath) {
+  return isRemotePath(filePath);
+}
+
+export async function setupStagedLogger(filePath) {
+  if (!shouldStageLogger(filePath)) return null;
+
+  const baseName = getLogBaseName(filePath);
+  const localLogPath = path.join(LOCAL_LOG_DIR, `Logger_${baseName}.txt`);
+
+  await mkdir(LOCAL_LOG_DIR, { recursive: true });
+
+  const networkLogDir = path.join(path.dirname(filePath), "loggers");
+  await mkdir(networkLogDir, { recursive: true });
+
+  const startPlaceholder = path.join(
+    networkLogDir,
+    `Logger_${baseName}_processamento_iniciado.txt`
+  );
+  const stamp = new Date().toISOString();
+  await writeFile(startPlaceholder, `Processamento iniciado em ${stamp}\n`);
+
+  return { baseName, localLogPath, networkLogDir, startPlaceholder };
+}
+
+export async function finalizeStagedLogger(stagedInfo, options = {}) {
+  if (!stagedInfo) return null;
+
+  const { skipCopy = false } = options;
+  const { baseName, localLogPath, networkLogDir, startPlaceholder } = stagedInfo;
+  let finalPath = null;
+
+  try {
+    if (!skipCopy && localLogPath && networkLogDir) {
+      finalPath = path.join(networkLogDir, `Logger_${baseName}.txt`);
+      await copyFile(localLogPath, finalPath);
+    }
+  } finally {
+    if (startPlaceholder) {
+      await unlink(startPlaceholder).catch(() => {});
+    }
+  }
+
+  return finalPath;
+}
+
+export { LOCAL_LOG_DIR };

--- a/src/utils/withFileLifecycle.js
+++ b/src/utils/withFileLifecycle.js
@@ -1,6 +1,9 @@
 import { startLogger, endLogger, logActivity } from "../middleware/logger.js";
 import { memoryGuard } from "./memoryGuard.js";
-import { clearAllErrors } from "../middleware/errorHandler.js";
+import {
+  clearAllErrors,
+  flushAggregatedSummaries,
+} from "../middleware/errorHandler.js";
 import {
   ensureJob,
   markJobActive,
@@ -8,6 +11,11 @@ import {
   updateActiveJob,
   updateMemoryGuardListeners,
 } from "./queueTracker.js";
+import {
+  finalizeStagedLogger,
+  setupStagedLogger,
+  shouldStageLogger,
+} from "./loggerStaging.js";
 
 const activeFiles = new Set();
 export function getActiveFilesCount() {
@@ -17,8 +25,47 @@ export function getActiveFilesCount() {
 export async function withFileLifecycle(filePath, fn, lifecycleOpts = {}) {
   const { manageLogger = true, loggerOptions } = lifecycleOpts;
 
+  let stagedLoggerInfo = null;
+  let loggerStarted = false;
+  let effectiveLoggerOptions = loggerOptions;
+
   if (manageLogger !== false) {
-    startLogger(filePath, loggerOptions);
+    effectiveLoggerOptions = { ...(loggerOptions || {}) };
+    if (!effectiveLoggerOptions.logPath && shouldStageLogger(filePath)) {
+      try {
+        stagedLoggerInfo = await setupStagedLogger(filePath);
+        if (stagedLoggerInfo?.localLogPath) {
+          effectiveLoggerOptions.logPath = stagedLoggerInfo.localLogPath;
+        }
+      } catch (err) {
+        stagedLoggerInfo = null;
+        console.error(
+          `[logger] Falha ao preparar log temporário (${filePath}):`,
+          err?.message || err
+        );
+      }
+    }
+
+    try {
+      startLogger(filePath, effectiveLoggerOptions);
+      loggerStarted = true;
+    } catch (err) {
+      console.error(
+        `[logger] Falha ao iniciar logger de ${filePath}:`,
+        err?.message || err
+      );
+      if (stagedLoggerInfo) {
+        try {
+          await finalizeStagedLogger(stagedLoggerInfo, { skipCopy: true });
+        } catch (cleanupErr) {
+          console.error(
+            `[logger] Falha ao descartar log temporário de ${filePath}:`,
+            cleanupErr?.message || cleanupErr
+          );
+        }
+        stagedLoggerInfo = null;
+      }
+    }
   }
   activeFiles.add(filePath);
 
@@ -50,11 +97,22 @@ export async function withFileLifecycle(filePath, fn, lifecycleOpts = {}) {
   } finally {
     try {
       if (manageLogger !== false) {
+        await flushAggregatedSummaries(filePath);
         await endLogger(filePath);
       }
     } catch (err) {
       console.error(`[logger] Falha ao finalizar logger de ${filePath}:`, err?.message || err);
     } finally {
+      if (stagedLoggerInfo) {
+        try {
+          await finalizeStagedLogger(stagedLoggerInfo, { skipCopy: !loggerStarted });
+        } catch (err) {
+          console.error(
+            `[logger] Falha ao consolidar log de ${filePath}:`,
+            err?.message || err
+          );
+        }
+      }
       off();
       updateMemoryGuardListeners(memoryGuard.listenerCount());
       clearAllErrors(filePath);


### PR DESCRIPTION
## Summary
- aggregate repeated error and warning messages while retaining a concise summary at the end of processing
- stage remote logger output on local storage and copy the final artifact to the network location after completion
- share the staging workflow across handlers so lifecycle utilities flush summaries and publish staged logs consistently

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d192a2025083248b6a333774345832