### PR TITLE
Improve logging lifecycle and monitoring metrics

### DIFF
--- a/src/controller/Handlers/createdHandler.js
+++ b/src/controller/Handlers/createdHandler.js
@@ -33,6 +33,7 @@ import {
   setupStagedLogger,
   shouldStageLogger,
 } from "../../utils/loggerStaging.js";
+import { iniciarBarra, finalizarBarra } from "../../utils/progressBar.js";
 
 function parseBoolean(value, defaultValue) {
   if (value == null) return defaultValue;
@@ -66,6 +67,28 @@ function createStagingLogger(filePath) {
   };
 }
 
+function buildContextTag(meta) {
+  if (!meta) return "";
+  const tabela = meta.tabela || meta?.destino?.tabela_destino || "tabela-desconhecida";
+  const ano = meta.ano ?? meta?.destino?.ano ?? meta?.range?.ano ?? "—";
+  return `[${tabela}][${ano}]`;
+}
+
+function formatBeginData(meta) {
+  if (!meta) return "—";
+  if (meta.ano != null) return String(meta.ano);
+  const start = meta?.range?.start;
+  if (start) {
+    const d = new Date(start);
+    if (!Number.isNaN(d?.getTime?.())) {
+      const month = String(d.getMonth() + 1).padStart(2, "0");
+      const day = String(d.getDate()).padStart(2, "0");
+      return `${d.getFullYear()}-${month}-${day}`;
+    }
+  }
+  return "—";
+}
+
 export default async function createdHandler(filePath, action, job) {
   const useFastPath = PIPELINE_FAST_PATH; // kept for compatibility
   if (!filePath) {
@@ -82,6 +105,13 @@ export default async function createdHandler(filePath, action, job) {
   let loggerEntry = null;
   let stagedLoggerInfo = null;
   const arquivo = filePath ? path.basename(filePath) : "";
+  let metadados = null;
+  let logData = null;
+  let contextTag = "";
+  let barraId = null;
+  let barraIniciada = false;
+  let beginRegistrado = false;
+
   try {
     const loggerOptions = {
       overwrite: true,
@@ -124,24 +154,6 @@ export default async function createdHandler(filePath, action, job) {
       }
     }
 
-    if (loggerEntry) {
-      try {
-        await writeBeginFile({
-          filePath,
-          arquivo: arquivo || "—",
-          tabela: "—",
-          dataStr: "—",
-          acao: "analyze",
-          hash: "—",
-        });
-      } catch (err) {
-        addAviso(
-          `[Logger] não foi possível registrar bloco inicial: ${err?.message || err}`,
-          filePath,
-        );
-      }
-    }
-
     await withFileLifecycle(
       filePath,
       async () => {
@@ -156,8 +168,6 @@ export default async function createdHandler(filePath, action, job) {
             : undefined;
 
         let stagingInfo = null;
-        let metadados;
-        let logData;
         let processingSucceeded = false;
 
         try {
@@ -185,6 +195,9 @@ export default async function createdHandler(filePath, action, job) {
               stagingInfo,
             });
             ({ metadados, logData } = result || {});
+            if (metadados) {
+              contextTag = buildContextTag(metadados);
+            }
           } catch (e) {
             addErro(`erro ao gerar os dados fundamentais, erro:${e.message}`, filePath);
             return;
@@ -195,18 +208,49 @@ export default async function createdHandler(filePath, action, job) {
             return;
           }
 
+          if (loggerEntry && !beginRegistrado) {
+            const tabelaLog = metadados?.tabela || metadados?.destino?.tabela_destino || "—";
+            try {
+              await writeBeginFile({
+                filePath,
+                arquivo: metadados.nome_arquivo || arquivo || "—",
+                tabela: tabelaLog,
+                dataStr: formatBeginData(metadados),
+                acao: action || "analyze",
+                hash: metadados?.hash || "—",
+              });
+              beginRegistrado = true;
+            } catch (err) {
+              addAviso(
+                `[Logger] ${contextTag ? `${contextTag} ` : ""}não foi possível registrar bloco inicial: ${
+                  err?.message || err
+                }`,
+                filePath,
+              );
+            }
+          }
+
+          if (!barraIniciada) {
+            const nomeArquivo = metadados.nome_arquivo ?? arquivo ?? "arquivo-desconhecido";
+            barraId = `${nomeArquivo}::${metadados.ano ?? "-"}::${metadados.tabela ?? "-"}`;
+            iniciarBarra(barraId, 100, nomeArquivo, metadados.tabela, metadados.ano);
+            barraIniciada = true;
+          }
+
+          const prefixInfo = (msg) => addInfo(`${contextTag} ${msg}`.trim(), filePath);
+          const prefixErro = (msg) => addErro(`${contextTag} ${msg}`.trim(), filePath);
+
           let fluxo;
           try {
             fluxo = await fluxoValidatorController(metadados, logData);
           } catch (e) {
-            addErro(`Erro ao validar fluxo de ingestão: ${e.message}`, filePath);
+            prefixErro(`Erro ao validar fluxo de ingestão: ${e.message}`);
             return;
           }
 
           if (fluxo !== "inserir" && fluxo !== "reprocessar") {
-            addInfo(
-              `[ARQUIVO IGNORADO] ${metadados.nome_arquivo} já existe e não foi modificado.`,
-              filePath
+            prefixInfo(
+              `[ARQUIVO IGNORADO] ${metadados.nome_arquivo} já existe e não foi modificado.`
             );
             await insertLog(logData);
             processingSucceeded = true;
@@ -219,11 +263,11 @@ export default async function createdHandler(filePath, action, job) {
             logData.mensagem_erro = resultado?.mensagem || null;
             logData.hash_arquivo = metadados.hash;
             logData.total_linhas = metadados.total_linhas;
-            if (resultado?.erro) addErro(logData.mensagem_erro, filePath);
+            if (resultado?.erro) prefixErro(logData.mensagem_erro);
           } catch (e) {
             logData.sucesso = false;
             logData.mensagem_erro = `Erro durante execução do managerDataController: ${e.message}`;
-            addErro(logData.mensagem_erro, filePath);
+            prefixErro(logData.mensagem_erro);
           } finally {
             await insertLog(logData);
           }
@@ -237,23 +281,25 @@ export default async function createdHandler(filePath, action, job) {
               if (processingSucceeded && cleanupOnSuccess) {
                 try {
                   await unlinkFile(stagingInfo.effectivePath);
-                  stagingLogger.info(
-                    `cópia local removida após sucesso (${stagingInfo.effectivePath})`
-                  );
-                } catch (err) {
-                  stagingLogger.warn(
-                    `falha ao remover cópia local (${stagingInfo.effectivePath}): ${err?.message || err}`
-                  );
-                }
-              } else if (!processingSucceeded) {
                 stagingLogger.info(
-                  `mantendo cópia local para análise (${stagingInfo.effectivePath})`
+                  `${contextTag ? `${contextTag} ` : ""}cópia local removida após sucesso (${stagingInfo.effectivePath})`
+                );
+              } catch (err) {
+                stagingLogger.warn(
+                  `${contextTag ? `${contextTag} ` : ""}falha ao remover cópia local (${stagingInfo.effectivePath}): ${
+                    err?.message || err
+                  }`
                 );
               }
+            } else if (!processingSucceeded) {
+              stagingLogger.info(
+                `${contextTag ? `${contextTag} ` : ""}mantendo cópia local para análise (${stagingInfo.effectivePath})`
+              );
             }
           }
+        }
 
-          if (stagingInfo?.stagingDir) {
+        if (stagingInfo?.stagingDir) {
             try {
               await cleanupStaging({
                 stagingDir: stagingInfo.stagingDir,
@@ -261,7 +307,9 @@ export default async function createdHandler(filePath, action, job) {
                 logger: stagingLogger,
               });
             } catch (err) {
-              stagingLogger.warn(`cleanup tardio falhou: ${err?.message || err}`);
+              stagingLogger.warn(
+                `${contextTag ? `${contextTag} ` : ""}cleanup tardio falhou: ${err?.message || err}`
+              );
             }
           }
         }
@@ -274,15 +322,19 @@ export default async function createdHandler(filePath, action, job) {
         await flushAggregatedSummaries(filePath);
       } catch (err) {
         addAviso(
-          `[Logger] não foi possível registrar resumos de erros/avisos: ${err?.message || err}`,
+          `[Logger] ${contextTag ? `${contextTag} ` : ""}não foi possível registrar resumos de erros/avisos: ${
+            err?.message || err
+          }`,
           filePath,
         );
       }
       try {
-        await writeFinal({ filePath });
+        await writeFinal({ filePath, dataStr: formatBeginData(metadados) });
       } catch (err) {
         addAviso(
-          `[Logger] não foi possível registrar bloco final: ${err?.message || err}`,
+          `[Logger] ${contextTag ? `${contextTag} ` : ""}não foi possível registrar bloco final: ${
+            err?.message || err
+          }`,
           filePath,
         );
       }
@@ -292,9 +344,22 @@ export default async function createdHandler(filePath, action, job) {
       await endLogger(filePath);
     } catch (err) {
       addAviso(
-        `[Logger] não foi possível encerrar logger dedicado: ${err?.message || err}`,
+        `[Logger] ${contextTag ? `${contextTag} ` : ""}não foi possível encerrar logger dedicado: ${
+          err?.message || err
+        }`,
         filePath,
       );
+    }
+
+    if (barraIniciada && barraId) {
+      try {
+        await finalizarBarra(barraId);
+      } catch (err) {
+        addAviso(
+          `[Progress] ${contextTag ? `${contextTag} ` : ""}falha ao finalizar barra: ${err?.message || err}`,
+          filePath,
+        );
+      }
     }
 
     if (stagedLoggerInfo) {
@@ -302,7 +367,9 @@ export default async function createdHandler(filePath, action, job) {
         await finalizeStagedLogger(stagedLoggerInfo);
       } catch (err) {
         addAviso(
-          `[Logger] Falha ao copiar log final para a rede: ${err?.message || err}`,
+          `[Logger] ${contextTag ? `${contextTag} ` : ""}Falha ao copiar log final para a rede: ${
+            err?.message || err
+          }`,
           filePath,
         );
       }

--- a/src/controller/createDataController.js
+++ b/src/controller/createDataController.js
@@ -46,6 +46,20 @@ function tailDirs(dir) {
 
   return [parent, grandParent, greatGrandParent];
 }
+
+function buildContextTag(meta) {
+  if (!meta) return "";
+  const tabela = meta.tabela || meta?.destino?.tabela_destino || "tabela-desconhecida";
+  const ano = meta.ano ?? meta?.destino?.ano ?? meta?.range?.ano ?? "—";
+  return `[${tabela}][${ano}]`;
+}
+
+function buildLogAction(meta) {
+  if (!meta) return undefined;
+  const tabela = meta.tabela || meta?.destino?.tabela_destino;
+  const ano = meta.ano ?? meta?.destino?.ano ?? meta?.range?.ano;
+  return [tabela, ano].filter((value) => value != null && value !== "").join(" ");
+}
 export function destinoByFilePath(filePath) {
   const { dir, base: fileName, name: baseNameNoExt } = path.parse(filePath);
   const [parent, grandParent, greatGrandParent] = tailDirs(dir);
@@ -339,7 +353,12 @@ async function ensureOverlapMetadata(metadados, contexto, action) {
   const range = metadados.range ?? buildRangeFromMetadados(metadados);
   metadados.range = range || null;
 
-  const logger = createOverlapLogger(contexto, action);
+  const logger = createOverlapLogger(
+    contexto,
+    action,
+    buildLogAction(metadados),
+    buildContextTag(metadados)
+  );
   const decision = await decideOverlapPolicy({
     table: metadados.tabela,
     dateCol: metadados.coluna_data,
@@ -350,17 +369,18 @@ async function ensureOverlapMetadata(metadados, contexto, action) {
   return decision;
 }
 
-function createOverlapLogger(contexto, action) {
+function createOverlapLogger(contexto, action, activityAction, contextTag = "") {
   return {
     info(message, payload = {}) {
       try {
         const serialized = JSON.stringify(payload);
         const line = `${message} ${serialized}`;
-        addInfo(line, contexto);
-        void logActivity("info", line, { filePath: contexto, action });
+        addInfo(contextTag ? `${contextTag} ${line}` : line, contexto);
+        void logActivity("info", line, { filePath: contexto, action: activityAction || action });
       } catch (err) {
-        addInfo(`${message} ${payload ? String(payload) : ""}`, contexto);
-        void logActivity("info", message, { filePath: contexto, action });
+        const fallback = `${message} ${payload ? String(payload) : ""}`;
+        addInfo(contextTag ? `${contextTag} ${fallback}` : fallback, contexto);
+        void logActivity("info", message, { filePath: contexto, action: activityAction || action });
       }
     },
   };

--- a/src/controller/fluxoValidatorController.js
+++ b/src/controller/fluxoValidatorController.js
@@ -5,12 +5,32 @@ import { buildRangeFromMetadados } from "../model/tableModel.js";
 import { logActivity } from "../middleware/logger.js";
 import { PIPELINE_FAST_PATH } from "../../config/index.js";
 
+function buildContextTag(meta) {
+  if (!meta) return "";
+  const tabela = meta.tabela || meta?.destino?.tabela_destino || "tabela-desconhecida";
+  const ano = meta.ano ?? meta?.destino?.ano ?? meta?.range?.ano ?? "—";
+  return `[${tabela}][${ano}]`;
+}
+
+function buildLogAction(meta) {
+  if (!meta) return undefined;
+  const tabela = meta.tabela || meta?.destino?.tabela_destino;
+  const ano = meta.ano ?? meta?.destino?.ano ?? meta?.range?.ano;
+  return [tabela, ano].filter((value) => value != null && value !== "").join(" ");
+}
+
 export default async function fluxoValidatorController(metadados, logData) {
   const contexto = metadados.caminho_original;
   const nome = metadados.nome_arquivo;
   const tabela = metadados.tabela;
 
   const fastPath = PIPELINE_FAST_PATH;
+  const contextTag = buildContextTag(metadados);
+  const actionContext = buildLogAction(metadados);
+  const withTag = (msg) => (contextTag ? `${contextTag} ${msg}` : msg);
+  const info = (msg) => addInfo(withTag(msg), contexto);
+  const erro = (msg) => addErro(withTag(msg), contexto);
+  const aviso = (msg) => addAviso(withTag(msg), contexto);
 
   const overlap = await ensureOverlapDecision(metadados, contexto);
   const strategy = overlap?.strategy || "insert";
@@ -22,27 +42,23 @@ export default async function fluxoValidatorController(metadados, logData) {
     hasOverlap,
     reason: overlap?.reason ?? null,
     range: metadados.range ?? null,
-  });
+  }, actionContext, contextTag);
 
   if (fastPath) {
     if (!logData?.hash_arquivo) {
-      addInfo(
-        "[Validator] FAST_PATH: hash indisponível nesta etapa — validação seguirá por range.",
-        contexto
+      info(
+        "[Validator] FAST_PATH: hash indisponível nesta etapa — validação seguirá por range."
       );
     }
     if (hasOverlap) {
-      addInfo(
-        `[ARQUIVO MODIFICADO] [${nome}] já existia, mas foi alterado. Reprocessando.`,
-        contexto
-      );
+      info(`[ARQUIVO MODIFICADO] [${nome}] já existia, mas foi alterado. Reprocessando.`);
       console.log(
         `[🟡 MODIFICADO] [${nome}] sera inserido na tabela [${tabela}]`
       );
       return "reprocessar";
     }
 
-    addInfo(`[NOVO ARQUIVO] [${nome}] será processado.`, contexto);
+    info(`[NOVO ARQUIVO] [${nome}] será processado.`);
     console.log(`[🟢 NOVO] [${nome}] sera inserido na tabela [${tabela}]`);
     return "inserir";
   }
@@ -50,7 +66,7 @@ export default async function fluxoValidatorController(metadados, logData) {
   const hash = logData?.hash_arquivo;
 
   if (!hash) {
-    addErro("Hash do arquivo não foi passado ao validador do fluxo.", contexto);
+    erro("Hash do arquivo não foi passado ao validador do fluxo.");
   }
 
   if (metadados?.file_size_bytes != null && metadados?.total_linhas != null) {
@@ -61,18 +77,17 @@ export default async function fluxoValidatorController(metadados, logData) {
         total_linhas: metadados.total_linhas,
       });
       if (similar) {
-        addInfo(
-          "[Validator] Meta match (size+lines) encontrado — provável duplicado; seguir com verificação por hash.",
-          contexto
+        info(
+          "[Validator] Meta match (size+lines) encontrado — provável duplicado; seguir com verificação por hash."
         );
       }
     } catch (e) {
-      addErro(`Erro ao buscar log por metadados: ${e.message}`, contexto);
+      erro(`Erro ao buscar log por metadados: ${e.message}`);
     }
   }
 
   const pLogs = getLogByData(metadados).catch((e) => {
-    addErro(`erro ao extrair os logs referentes à data: ${e.message}`, contexto);
+    erro(`erro ao extrair os logs referentes à data: ${e.message}`);
     return null;
   });
 
@@ -86,7 +101,7 @@ export default async function fluxoValidatorController(metadados, logData) {
           return false;
         })
         .catch((e) => {
-          addErro(`Erro ao extrair os hashes: ${e.message}`, contexto);
+          erro(`Erro ao extrair os hashes: ${e.message}`);
           return false;
         })
     : Promise.resolve(false);
@@ -94,10 +109,7 @@ export default async function fluxoValidatorController(metadados, logData) {
   const [logs, hashJaExiste] = await Promise.all([pLogs, pHashExiste]);
 
   if (hashJaExiste) {
-    addInfo(
-      `[ARQUIVO DUPLICADO] O conteúdo de [${nome}] já está presente na base, ${tabela}.`,
-      contexto
-    );
+    info(`[ARQUIVO DUPLICADO] O conteúdo de [${nome}] já está presente na base, ${tabela}.`);
     console.log(
       `[🟠 DUPLICADO] [${nome}] não sera inserido na tabela [${tabela}]`
     );
@@ -105,15 +117,12 @@ export default async function fluxoValidatorController(metadados, logData) {
   }
 
   if (!logs || logs.length === 0) {
-    addInfo(`[NOVO ARQUIVO] [${nome}] será processado.`, contexto);
+    info(`[NOVO ARQUIVO] [${nome}] será processado.`);
     console.log(`[🟢 NOVO] [${nome}] sera inserido na tabela [${tabela}]`);
     return "inserir";
   }
 
-  addInfo(
-    `[ARQUIVO MODIFICADO] [${nome}] já existia, mas foi alterado. Reprocessando.`,
-    contexto
-  );
+  info(`[ARQUIVO MODIFICADO] [${nome}] já existia, mas foi alterado. Reprocessando.`);
   console.log(
     `[🟡 MODIFICADO] [${nome}] sera inserido na tabela [${tabela}], validar lógica de atualização para o tipo do arquivo`
   );
@@ -129,9 +138,12 @@ async function ensureOverlapDecision(metadados, contexto) {
     return metadados.overlap;
   }
 
-  addAviso(
-    "[OverlapDecision] Metadados sem decisão prévia; calculando tardiamente.",
-    contexto
+  const contextTag = buildContextTag(metadados);
+  const actionContext = buildLogAction(metadados);
+  aviso(
+    contextTag
+      ? `${contextTag} [OverlapDecision] Metadados sem decisão prévia; calculando tardiamente.`
+      : "[OverlapDecision] Metadados sem decisão prévia; calculando tardiamente.",
   );
   const range = metadados.range ?? buildRangeFromMetadados(metadados);
   metadados.range = range || null;
@@ -139,35 +151,39 @@ async function ensureOverlapDecision(metadados, contexto) {
     table: metadados.tabela,
     dateCol: metadados.coluna_data,
     range,
-    logger: createOverlapLogger(contexto),
+    logger: createOverlapLogger(contexto, metadados.acao, actionContext, contextTag),
   });
   metadados.overlap = decision;
   return decision;
 }
 
-function createOverlapLogger(contexto) {
+function createOverlapLogger(contexto, actionContext, contextTag = "") {
   return {
     info(message, payload = {}) {
       try {
         const serialized = JSON.stringify(payload);
         const line = `${message} ${serialized}`;
-        addInfo(line, contexto);
-        void logActivity("info", line, { filePath: contexto });
+        addInfo(contextTag ? `${contextTag} ${line}` : line, contexto);
+        void logActivity("info", line, { filePath: contexto, action: actionContext });
       } catch (err) {
-        addInfo(`${message} ${payload ? String(payload) : ""}`, contexto);
-        void logActivity("info", message, { filePath: contexto });
+        const fallback = `${message} ${payload ? String(payload) : ""}`;
+        addInfo(contextTag ? `${contextTag} ${fallback}` : fallback, contexto);
+        void logActivity("info", message, { filePath: contexto, action: actionContext });
       }
     },
   };
 }
 
-function logOverlapUsage(contexto, payload) {
+function logOverlapUsage(contexto, payload, actionContext, contextTag = "") {
   try {
     const line = `[OverlapDecision][Use] ${JSON.stringify(payload)}`;
-    addInfo(line, contexto);
-    void logActivity("info", line, { filePath: contexto });
+    addInfo(contextTag ? `${contextTag} ${line}` : line, contexto);
+    void logActivity("info", line, { filePath: contexto, action: actionContext });
   } catch (err) {
-    addInfo("[OverlapDecision][Use]", contexto);
-    void logActivity("info", "[OverlapDecision][Use]", { filePath: contexto });
+    const fallback = contextTag
+      ? `${contextTag} [OverlapDecision][Use]`
+      : "[OverlapDecision][Use]";
+    addInfo(fallback, contexto);
+    void logActivity("info", "[OverlapDecision][Use]", { filePath: contexto, action: actionContext });
   }
 }

--- a/src/controller/managerDataController.js
+++ b/src/controller/managerDataController.js
@@ -1,10 +1,6 @@
 import path from "path";
 import { deleteFromTable, buildRangeFromMetadados } from "../model/tableModel.js";
-import {
-  iniciarBarra,
-  atualizarBarra,
-  finalizarBarra,
-} from "../utils/progressBar.js";
+import { atualizarBarra } from "../utils/progressBar.js";
 
 import { addAviso, addErro, addInfo } from "../middleware/errorHandler.js";
 import { logActivity, writeStatusUpdate } from "../middleware/logger.js";
@@ -31,18 +27,39 @@ import {
 import { updateActiveJob } from "../utils/queueTracker.js";
 import { normalizeTotal } from "../utils/normalizeTotal.js";
 
+function buildContextTag(metadados) {
+  if (!metadados) return "";
+  const tabela = metadados.tabela || metadados?.destino?.tabela_destino || "tabela-desconhecida";
+  const ano = metadados.ano ?? metadados?.destino?.ano ?? metadados?.range?.ano ?? "—";
+  return `[${tabela}][${ano}]`;
+}
+
+function buildLogAction(metadados) {
+  if (!metadados) return undefined;
+  const tabela = metadados.tabela || metadados?.destino?.tabela_destino;
+  const ano = metadados.ano ?? metadados?.destino?.ano ?? metadados?.range?.ano;
+  return [tabela, ano].filter((value) => value != null && value !== "").join(" ");
+}
+
 export async function manageInsertController(metadados, logData) {
   const contexto = metadados.caminho_original;
   const workPath = metadados.paths?.work || contexto;
   const nomeArquivo = metadados.nome_arquivo ?? "arquivo-desconhecido";
   const barraId = `${nomeArquivo}::${metadados.ano ?? "-"}::${metadados.tabela}`;
+  const contextTag = buildContextTag(metadados);
+  const activityAction = buildLogAction(metadados);
+  const withTag = (msg) => (contextTag ? `${contextTag} ${msg}` : msg);
+  const info = (msg) => addInfo(withTag(msg), contexto);
+  const erro = (msg) => addErro(withTag(msg), contexto);
+  const aviso = (msg) => addAviso(withTag(msg), contexto);
+  const activity = (level, message) =>
+    logActivity(level, message, { filePath: contexto, action: activityAction });
 
   console.log(`[DB] Using pool limit=${POOL_MAX} | insert_concurrency=${INSERT_MAX_CONCURRENT} | files_concurrency=${FILES_MAX_CONCURRENT}`);
-  addInfo(
+  info(
     `Configuração: INSERT_MAX_CONCURRENT=${INSERT_MAX_CONCURRENT}, FILES_MAX_CONCURRENT=${FILES_MAX_CONCURRENT}, BATCH_SIZE=${BATCH_SIZE}, QUEUE_HIGH_WATERMARK=${HIGH_WATERMARK_DEFAULT}, QUEUE_LOW_WATERMARK=${LOW_WATERMARK_DEFAULT}`,
-    contexto,
   );
-  void logActivity("info", "Preparação iniciada", { filePath: contexto });
+  void activity("info", "Preparação iniciada");
   updateActiveJob(contexto, { stage: "preparação", detail: "Coletando metadados" });
 
   // -------- Barra global: 0..100 (3 fases) --------
@@ -52,8 +69,6 @@ export async function manageInsertController(metadados, logData) {
   let lastPctAbs = 0;
   const stageNames = { prep: "preparação", read: "leitura", insert: "inserção" };
   let currentStageName = stageNames.prep;
-
-  iniciarBarra(barraId, 100, nomeArquivo, metadados.tabela, metadados.ano);
 
   function setPhase(name) {
     phaseBase += phaseSpan;
@@ -106,11 +121,11 @@ export async function manageInsertController(metadados, logData) {
     // Tipos esperados (schema + overrides)
     const schemaMap = await loadDecimalProfilesFromSchema(metadados.tabela);
     const tiposFinal = expandTiposWithSchema(metadados.tipos_esperados, schemaMap);
-    void logActivity("info", "Preparação concluída", { filePath: contexto });
+    void activity("info", "Preparação concluída");
 
     publish(1.0, "Preparação concluída");
     setPhase("read"); // 15..60%
-    void logActivity("info", "Leitura e validação iniciadas", { filePath: contexto });
+    void activity("info", "Leitura e validação iniciadas");
 
     // -------- Valida dados e ação --------
     let totalKnown = normalizeTotal(metadados.total_linhas);
@@ -161,7 +176,7 @@ export async function manageInsertController(metadados, logData) {
       };
       if (primaryLabel) payload[primaryLabel] = primaryValue;
 
-      addInfo(`[Progress] ${JSON.stringify(payload)}`, contexto);
+      info(`[Progress] ${JSON.stringify(payload)}`);
       progressLogState.set(stageName, {
         lastPercent: percentVal,
         lastValue: primaryValue,
@@ -180,7 +195,7 @@ export async function manageInsertController(metadados, logData) {
       reason: overlapDecision?.reason ?? null,
       range: metadados.range ?? null,
       applyPreDelete: metadados.applyPreDelete,
-    });
+    }, activityAction, contextTag);
 
     const validator = strategy === "replace"
       ? metadados.coluna_data ? "substituir" : "cadastro"
@@ -188,22 +203,22 @@ export async function manageInsertController(metadados, logData) {
 
     if (validator === "cadastro" || validator === "substituir") {
       try {
-        void logActivity("info", "Removendo período anterior", { filePath: contexto });
+        void activity("info", "Removendo período anterior");
         await deleteFromTable(metadados);
         const msg = validator === "cadastro"
           ? "[Delete dados] tabela limpa para reinserção cadastral"
           : "[Gerenciamento] substituição: período removido antes da reinserção";
-        addInfo(msg, contexto);
-        void logActivity("info", "Remoção concluída", { filePath: contexto });
+        info(msg);
+        void activity("info", "Remoção concluída");
       } catch (e) {
-        addErro(`Erro ao deletar antes da reinserção: ${e.message}`, contexto);
-        void logActivity("error", `Falha ao deletar período: ${e.message}`, { filePath: contexto });
+        erro(`Erro ao deletar antes da reinserção: ${e.message}`);
+        void activity("error", `Falha ao deletar período: ${e.message}`);
         throw e;
       }
     }
 
-    addInfo("Iniciando leitura e montagem de lotes...", contexto);
-    void logActivity("info", "Pipeline de streaming iniciado", { filePath: contexto });
+    info("Iniciando leitura e montagem de lotes...");
+    void activity("info", "Pipeline de streaming iniciado");
     updateActiveJob(contexto, { stage: "leitura", detail: "Stream iniciada", progress: lastPctAbs / 100 });
 
     try {
@@ -253,7 +268,7 @@ export async function manageInsertController(metadados, logData) {
         lastPctAbs = 100;
       }
 
-      addInfo("Processo de inserção finalizado.", contexto);
+      info("Processo de inserção finalizado.");
       try {
         const arquivo = path.basename(contexto || "");
         const tabelaFin =
@@ -289,22 +304,17 @@ export async function manageInsertController(metadados, logData) {
           hash: metadados?.hash || "—",
         });
       } catch (err) {
-        addAviso(
-          `[Status] não foi possível registrar atualização: ${err?.message || err}`,
-          contexto,
-        );
+        aviso(`[Status] não foi possível registrar atualização: ${err?.message || err}`);
       }
-      void logActivity("info", "Pipeline de streaming concluído", { filePath: contexto });
+      void activity("info", "Pipeline de streaming concluído");
       updateActiveJob(contexto, { stage: "finalização", progress: 1, detail: "Processo concluído" });
 
       return resultado;
     } catch (e) {
-      addErro(`Falha no pipeline de leitura/inserção: ${e.message}`, contexto);
-      void logActivity("error", `Falha no pipeline: ${e.message}`, { filePath: contexto });
+      erro(`Falha no pipeline de leitura/inserção: ${e.message}`);
+      void activity("error", `Falha no pipeline: ${e.message}`);
       throw e;
     }
-  } finally {
-    await finalizarBarra(barraId);
   }
 }
 
@@ -318,8 +328,11 @@ async function ensureOverlapDecision(metadados, contexto) {
     return metadados.overlap;
   }
 
+  const contextTag = buildContextTag(metadados);
   addAviso(
-    "[OverlapDecision] Metadados sem decisão prévia; calculando tardiamente (manager).",
+    contextTag
+      ? `${contextTag} [OverlapDecision] Metadados sem decisão prévia; calculando tardiamente (manager).`
+      : "[OverlapDecision] Metadados sem decisão prévia; calculando tardiamente (manager).",
     contexto
   );
   const range = metadados.range ?? buildRangeFromMetadados(metadados);
@@ -328,53 +341,69 @@ async function ensureOverlapDecision(metadados, contexto) {
     table: metadados.tabela,
     dateCol: metadados.coluna_data,
     range,
-    logger: createOverlapLogger(contexto, metadados.acao),
+    logger: createOverlapLogger(
+      contexto,
+      metadados.acao,
+      buildLogAction(metadados),
+      contextTag
+    ),
   });
   metadados.overlap = decision;
   return decision;
 }
 
-function createOverlapLogger(contexto, action) {
+function createOverlapLogger(contexto, action, activityAction, contextTag = "") {
   return {
     info(message, payload = {}) {
       try {
         const serialized = JSON.stringify(payload);
         const line = `${message} ${serialized}`;
-        addInfo(line, contexto);
-        void logActivity("info", line, { filePath: contexto, action });
+        addInfo(contextTag ? `${contextTag} ${line}` : line, contexto);
+        void logActivity("info", line, { filePath: contexto, action: activityAction || action });
       } catch (err) {
-        addInfo(`${message} ${payload ? String(payload) : ""}`, contexto);
-        void logActivity("info", message, { filePath: contexto, action });
+        const fallback = `${message} ${payload ? String(payload) : ""}`;
+        addInfo(contextTag ? `${contextTag} ${fallback}` : fallback, contexto);
+        void logActivity("info", message, { filePath: contexto, action: activityAction || action });
       }
     },
   };
 }
 
-function logManageStrategy(contexto, payload) {
+function logManageStrategy(contexto, payload, activityAction, contextTag = "") {
   try {
     const line = `[ManageInsert] ${JSON.stringify(payload)}`;
-    addInfo(line, contexto);
-    void logActivity("info", line, { filePath: contexto });
+    addInfo(contextTag ? `${contextTag} ${line}` : line, contexto);
+    void logActivity("info", line, { filePath: contexto, action: activityAction });
   } catch (err) {
-    addInfo("[ManageInsert]", contexto);
-    void logActivity("info", "[ManageInsert]", { filePath: contexto });
+    const fallbackLine = contextTag ? `${contextTag} [ManageInsert]` : "[ManageInsert]";
+    addInfo(fallbackLine, contexto);
+    void logActivity("info", "[ManageInsert]", { filePath: contexto, action: activityAction });
   }
 }
 
 
 export async function managerDeleterController(logData) {
   const contexto = logData.caminho_original;
+  const contextTag = buildContextTag(logData);
+  const activityAction = buildLogAction(logData);
+  const withTag = (msg) => (contextTag ? `${contextTag} ${msg}` : msg);
 
   try {
-    void logActivity("info", "Fluxo de deleção iniciado", { filePath: contexto });
+    void logActivity("info", "Fluxo de deleção iniciado", { filePath: contexto, action: activityAction });
     const res = await deleteFromTable(logData);
     const removidos = res?.affectedRows ?? res?.affected_rows ?? 0;
-    addInfo( `[DELETE] Removidos ${removidos} registros de ${logData.tabela || logData.tabela_destino}.`, contexto );
-    void logActivity("info", `Fluxo de deleção concluído (${removidos} registros)`, { filePath: contexto });
+    addInfo(withTag(`[DELETE] Removidos ${removidos} registros de ${logData.tabela || logData.tabela_destino}.`), contexto);
+    void logActivity("info", `Fluxo de deleção concluído (${removidos} registros)`, {
+      filePath: contexto,
+      action: activityAction,
+    });
     return { erro: false, removidos };
   } catch (e) {
-    addErro( `Erro ao deletar período no banco pós exclusão do arquivo, erro: ${e.message}`, contexto);
-    void logActivity("error", `Erro durante deleção: ${e.message}`, { filePath: contexto });
+    addErro(withTag(`Erro ao deletar período no banco pós exclusão do arquivo, erro: ${e.message}`), contexto);
+    void logActivity("error", `Erro durante deleção: ${e.message}`, {
+      filePath: contexto,
+      action: activityAction,
+    });
     return { erro: true, mensagem: e.message };
   }
 }

--- a/src/monitoring/watchdog.js
+++ b/src/monitoring/watchdog.js
@@ -1,5 +1,9 @@
+import os from "node:os";
 import { logActivity } from "../middleware/logger.js";
 import { updateMetrics as updateQueueMetrics, updateMemoryGuardListeners } from "../utils/queueTracker.js";
+import { query } from "../../config/dbPool.js";
+
+let dbCheckInFlight = false;
 
 export function startWatchdog(getMetrics, intervalMs = 60000, stallMs = Number(process.env.STALL_MS || 5 * 60 * 1000)) {
   const interval = setInterval(() => {
@@ -10,6 +14,8 @@ export function startWatchdog(getMetrics, intervalMs = 60000, stallMs = Number(p
       lastProgressTs: m.lastProgressTs,
       activeFiles: m.activeFiles,
       filesMaxConcurrent: m.filesMaxConcurrent,
+      memoryUsage: process.memoryUsage(),
+      loadAverage: os.loadavg(),
     });
     updateMemoryGuardListeners(m.memoryGuardListeners);
 
@@ -18,6 +24,52 @@ export function startWatchdog(getMetrics, intervalMs = 60000, stallMs = Number(p
         "warn",
         `Watchdog: possível stall detectado (pending=${m.pendingBatches}, inflight=${m.inFlightInserts})`
       );
+    }
+
+    if (!dbCheckInFlight) {
+      dbCheckInFlight = true;
+      void (async () => {
+        const started = Date.now();
+        try {
+          const [{ total } = {}] = await query(
+            "SELECT COUNT(*) AS total FROM information_schema.processlist"
+          );
+          const statusRows = await query("SHOW STATUS LIKE 'Threads_connected'");
+          const threadsConnectedRaw =
+            statusRows?.[0]?.Value ?? statusRows?.[0]?.value ?? null;
+          const threadsConnected = threadsConnectedRaw != null ? Number(threadsConnectedRaw) : null;
+          const latencyMs = Date.now() - started;
+          const processCountNumber = Number(total);
+          updateQueueMetrics({
+            dbStatus: {
+              processCount: Number.isFinite(processCountNumber)
+                ? processCountNumber
+                : total,
+              threadsConnected: Number.isFinite(threadsConnected)
+                ? threadsConnected
+                : threadsConnectedRaw,
+              latencyMs,
+              checkedAt: Date.now(),
+            },
+          });
+          void logActivity(
+            "info",
+            `DB status: threads=${threadsConnected ?? threadsConnectedRaw ?? "n/a"} | processlist=${total ?? "n/a"} | latency=${latencyMs}ms`,
+            { action: "db-status" }
+          );
+        } catch (err) {
+          const message = err?.message || String(err);
+          updateQueueMetrics({
+            dbStatus: {
+              error: message,
+              checkedAt: Date.now(),
+            },
+          });
+          void logActivity("error", `DB status check failed: ${message}`, { action: "db-status" });
+        } finally {
+          dbCheckInFlight = false;
+        }
+      })();
     }
   }, intervalMs);
   interval.unref?.();

--- a/src/utils/queueTracker.js
+++ b/src/utils/queueTracker.js
@@ -22,6 +22,9 @@ const state = {
     lastProgressTs: Date.now(),
     activeFiles: 0,
     filesMaxConcurrent: null,
+    memoryUsage: null,
+    loadAverage: null,
+    dbStatus: null,
   },
 };
 
@@ -65,6 +68,10 @@ function buildSnapshot() {
   const lastProgressAgo = state.metrics.lastProgressTs
     ? `${Math.max(0, now - state.metrics.lastProgressTs)}ms`
     : "n/a";
+  const mem = state.metrics.memoryUsage;
+  const loadAvg = state.metrics.loadAverage;
+  const dbStatus = state.metrics.dbStatus;
+  const formatMb = (value) => (value != null ? (value / (1024 * 1024)).toFixed(1) : "0.0");
 
   lines.push(`Snapshot: ${fmtTimeNow()}`);
   lines.push(`FILES_MAX_CONCURRENT=${filesMax}`);
@@ -121,6 +128,33 @@ function buildSnapshot() {
   lines.push(
     `pendingBatches=${state.metrics.pendingBatches} | inFlight=${state.metrics.inFlightInserts} | lastProgressAgo=${lastProgressAgo}`
   );
+
+  if (mem) {
+    lines.push(
+      `Memória RSS: ${formatMb(mem.rss)} MB | Heap Usado: ${formatMb(mem.heapUsed)} MB | Heap Total: ${formatMb(mem.heapTotal)} MB`
+    );
+  }
+
+  if (Array.isArray(loadAvg) && loadAvg.length) {
+    const loadFormatted = loadAvg.map((value) => (Number.isFinite(value) ? value.toFixed(2) : "n/a"));
+    lines.push(`Carga CPU (1,5,15min): [${loadFormatted.join(", ")}]`);
+  }
+
+  if (dbStatus) {
+    const checkedAt = dbStatus.checkedAt
+      ? new Date(dbStatus.checkedAt).toISOString()
+      : "n/a";
+    if (dbStatus.error) {
+      lines.push(`DB status erro: ${dbStatus.error} | Última verificação: ${checkedAt}`);
+    } else {
+      const threads = dbStatus.threadsConnected ?? "n/a";
+      const processes = dbStatus.processCount ?? "n/a";
+      const latency = dbStatus.latencyMs != null ? `${dbStatus.latencyMs}ms` : "n/a";
+      lines.push(
+        `DB Threads conectados: ${threads} | Processlist: ${processes} | Latência: ${latency} | Última verificação: ${checkedAt}`
+      );
+    }
+  }
 
   return `${lines.join("\n")}\n`;
 }

--- a/src/utils/streamPipeline.js
+++ b/src/utils/streamPipeline.js
@@ -25,6 +25,20 @@ import {
 import { logActivity } from "../middleware/logger.js";
 import { updateActiveJob, updateMetrics } from "./queueTracker.js";
 
+function buildContextTag(metadados) {
+  if (!metadados) return "";
+  const tabela = metadados.tabela || metadados?.destino?.tabela_destino || "tabela-desconhecida";
+  const ano = metadados.ano ?? metadados?.destino?.ano ?? metadados?.range?.ano ?? "—";
+  return `[${tabela}][${ano}]`;
+}
+
+function buildLogAction(metadados) {
+  if (!metadados) return undefined;
+  const tabela = metadados.tabela || metadados?.destino?.tabela_destino;
+  const ano = metadados.ano ?? metadados?.destino?.ano ?? metadados?.range?.ano;
+  return [tabela, ano].filter((value) => value != null && value !== "").join(" ");
+}
+
 const CPU = Math.max(1, os.cpus()?.length ?? 1);
 const pool = await getPool();
 export const POOL_MAX = pool.pool?.max ?? 10;
@@ -73,6 +87,15 @@ export async function streamPipeline(
   } = metadados;
   const workPath = metadados.paths?.work || contexto;
 
+  const contextTag = buildContextTag(metadados);
+  const activityAction = buildLogAction(metadados);
+  const withTag = (msg) => (contextTag ? `${contextTag} ${msg}` : msg);
+  const info = (msg) => addInfo(withTag(msg), contexto);
+  const aviso = (msg) => addAviso(withTag(msg), contexto);
+  const erro = (msg) => addErro(withTag(msg), contexto);
+  const activity = (level, message) =>
+    logActivity(level, message, { filePath: contexto, action: activityAction });
+
   memoryGuard.start();
 
   let dynamicAllowedInserts = MAX_CONCURRENT_INSERTS_DEFAULT;
@@ -89,24 +112,22 @@ export async function streamPipeline(
         dynamicMaxBatchBytes,
         MAX_BATCH_BYTES_WHEN_HIGH
       );
-      addInfo(
+      info(
         "[RAM] HIGH: reduzindo concorrência para 1, HIGH_WATERMARK=1, maxBatchBytes=" +
-          dynamicMaxBatchBytes,
-        contexto
+          dynamicMaxBatchBytes
       );
     } else {
       dynamicAllowedInserts = MAX_CONCURRENT_INSERTS_DEFAULT;
       dynamicHighWatermark = HIGH_WATERMARK_DEFAULT;
       dynamicLowWatermark = LOW_WATERMARK_DEFAULT;
       dynamicMaxBatchBytes = MAX_BATCH_BYTES_DEFAULT;
-      addInfo(
+      info(
         "[RAM] NORMAL: restaurando concorrência=" +
           dynamicAllowedInserts +
           ", HIGH_WATERMARK=" +
           dynamicHighWatermark +
           ", maxBatchBytes=" +
-          dynamicMaxBatchBytes,
-        contexto
+          dynamicMaxBatchBytes
       );
     }
   });
@@ -160,9 +181,7 @@ export async function streamPipeline(
         detail: "Inserções iniciadas",
       });
     }
-    void logActivity("info", `Inserindo lote (${lote.length} linhas)`, {
-      filePath: contexto,
-    });
+    void activity("info", `Inserindo lote (${lote.length} linhas)`);
     updateActiveJob(contexto, { detail: `Inserindo lote (${lote.length})` });
     try {
       const skipUpdateClause = Boolean(metadados.applyPreDelete); // só pula UPDATE se fizemos pre-delete
@@ -170,16 +189,10 @@ export async function streamPipeline(
       inseridosAteAgora += lote.length;
       publishInsert?.(inseridosAteAgora);
       metrics.lastProgressTs = Date.now();
-      void logActivity("info", `Lote concluído (${lote.length} linhas)`, {
-        filePath: contexto,
-      });
+      void activity("info", `Lote concluído (${lote.length} linhas)`);
     } catch (e) {
-      addAviso(`[BATCH][FALLBACK] Falha no lote de ${lote.length}. Provável duplicata/constraint.`, contexto);
-      void logActivity(
-        "warn",
-        `Fallback para inserção linha-a-linha: ${e.message}`,
-        { filePath: contexto }
-      );
+      aviso(`[BATCH][FALLBACK] Falha no lote de ${lote.length}. Provável duplicata/constraint.`);
+      void activity("warn", `Fallback para inserção linha-a-linha: ${e.message}`);
       let ok = 0,
         fail = 0;
       for (const row of lote) {
@@ -189,10 +202,7 @@ export async function streamPipeline(
           inseridosAteAgora++;
         } catch (err) {
           fail++;
-          addErro(
-            `Erro ao inserir linha ${inseridosAteAgora + 1}: ${err.message}`,
-            contexto
-          );
+          erro(`Erro ao inserir linha ${inseridosAteAgora + 1}: ${err.message}`);
         }
       }
       updateActiveJob(contexto, {
@@ -201,10 +211,7 @@ export async function streamPipeline(
       publishInsert?.(inseridosAteAgora);
       metrics.lastProgressTs = Date.now();
     } finally {
-      addInfo(
-        `[BATCH] Inseridos ${lote.length} linhas (até agora: ${inseridosAteAgora}).`,
-        contexto
-      );
+      info(`[BATCH] Inseridos ${lote.length} linhas (até agora: ${inseridosAteAgora}).`);
     }
   }
 
@@ -232,9 +239,8 @@ export async function streamPipeline(
       metrics.inFlightInserts = inflight.size;
       updateActiveJob(contexto, { detail: `Lotes em voo: ${inflight.size}` });
     });
-    addInfo(
-      `[FLUSH] inflight_inserts=${inflight.size}, batch_len=${lote.length}, approx_bytes=${loteBytes}`,
-      contexto
+    info(
+      `[FLUSH] inflight_inserts=${inflight.size}, batch_len=${lote.length}, approx_bytes=${loteBytes}`
     );
     updateActiveJob(contexto, {
       detail: `Enviando lote (${lote.length} linhas)`,
@@ -310,20 +316,16 @@ export async function streamPipeline(
   await Promise.all(inflight);
 
   const avgMs = insertCount ? totalInsertTime / insertCount : 0;
-  addInfo(
+  info(
     `[STATS] tempo_medio_lote=${avgMs.toFixed(
       2
-    )}ms, pico_inflight=${maxInflight}`,
-    contexto
+    )}ms, pico_inflight=${maxInflight}`
   );
-  void logActivity(
+  void activity(
     "info",
     `[STATS] tempo_medio_lote=${avgMs.toFixed(
       2
-    )}ms, pico_inflight=${maxInflight}`,
-    {
-      filePath: contexto,
-    }
+    )}ms, pico_inflight=${maxInflight}`
   );
 
   metadados.total_linhas = lidas;


### PR DESCRIPTION
## Summary
- start file loggers and progress bars with file metadata and close them after stream completion
- propagate table/year context into manager, validator and streaming logs for clearer diagnostics
- extend queue snapshots and watchdog with hardware metrics and periodic database health checks

## Testing
- not run (no automated tests available)

------
https://chatgpt.com/codex/tasks/task_e_68d59a1c4868832488228dbd0b0b53f4